### PR TITLE
referenced file not installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,11 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=setuptools.find_packages(),
+    package_data={
+        "empirical": [
+            "util/*.yaml",
+        ]
+    },
     scripts=[
         "empirical/scripts/calculate_empirical.py",
         "empirical/scripts/emp_aggregation.py",


### PR DESCRIPTION
not sure what it does yet, but there is a function (empirical_factory.read_model_dict) and its dependency isn't installed so I added it to setup.py