### PR TITLE
Fix the data type

### DIFF
--- a/empirical/GMM_models/meta_model.py
+++ b/empirical/GMM_models/meta_model.py
@@ -50,19 +50,20 @@ def meta_model(fault, site, im, weights_path=None, period=None, config=None, **k
             tmp_params_dict = config[gmm]
         else:
             tmp_params_dict = {}
+
         res = compute_gmm(
             fault, site, GMM[gmm], im, period, **tmp_params_dict, **kwargs
         )
+
         if isinstance(res, tuple):
             median, (sigma, _, _) = res
+            median = median[0] if isinstance(median, Iterable) else median
         else:
-            median = [x[0] for x in res]
-            sigma = [x[1][0] for x in res]
-
-        if isinstance(median, Iterable):
-            median = median[0]
-        if isinstance(sigma, Iterable):
-            sigma = sigma[0]
+            if len(res) == 1:
+                median, (sigma, _, _) = res[0]
+            else:
+                median = [x[0] for x in res]
+                sigma = [x[1][0] for x in res]
 
         medians.append(median)
         sigmas.append(sigma)

--- a/empirical/GMM_models/meta_model.py
+++ b/empirical/GMM_models/meta_model.py
@@ -53,7 +53,6 @@ def meta_model(fault, site, im, weights_path=None, period=None, config=None, **k
         res = compute_gmm(
             fault, site, GMM[gmm], im, period, **tmp_params_dict, **kwargs
         )
-
         if isinstance(res, tuple):
             median, (sigma, _, _) = res
             median = median[0] if isinstance(median, Iterable) else median

--- a/empirical/GMM_models/meta_model.py
+++ b/empirical/GMM_models/meta_model.py
@@ -1,3 +1,5 @@
+from collections.abc import Iterable
+
 import numpy as np
 
 
@@ -44,6 +46,8 @@ def meta_model(fault, site, im, weights_path=None, period=None, config=None, **k
     sigmas = []
 
     for gmm in models:
+        # if im == "pSA" and str(fault.tect_type) == "SUBDUCTION_SLAB":
+        #     breakpoint()
         if config is not None and gmm in config.keys():
             tmp_params_dict = config[gmm]
         else:
@@ -56,6 +60,12 @@ def meta_model(fault, site, im, weights_path=None, period=None, config=None, **k
         else:
             median = [x[0] for x in res]
             sigma = [x[1][0] for x in res]
+
+        if isinstance(median, Iterable):
+            median = median[0]
+        if isinstance(sigma, Iterable):
+            sigma = sigma[0]
+
         medians.append(median)
         sigmas.append(sigma)
 
@@ -86,4 +96,6 @@ def meta_model(fault, site, im, weights_path=None, period=None, config=None, **k
     else:
         res = [(e_medians, (e_sigmas, sigma_average, sigma_intermodel))]
 
+    if not isinstance(res, list):
+        print(res)
     return res

--- a/empirical/GMM_models/meta_model.py
+++ b/empirical/GMM_models/meta_model.py
@@ -50,7 +50,6 @@ def meta_model(fault, site, im, weights_path=None, period=None, config=None, **k
             tmp_params_dict = config[gmm]
         else:
             tmp_params_dict = {}
-
         res = compute_gmm(
             fault, site, GMM[gmm], im, period, **tmp_params_dict, **kwargs
         )

--- a/empirical/GMM_models/meta_model.py
+++ b/empirical/GMM_models/meta_model.py
@@ -60,8 +60,8 @@ def meta_model(fault, site, im, weights_path=None, period=None, config=None, **k
             if len(res) == 1:
                 median, (sigma, _, _) = res[0]
             else:
-                median = [x[0] for x in res]
-                sigma = [x[1][0] for x in res]
+                median, sigma_tuple = zip(*res)
+                sigma, __, __ = zip(*sigma_tuple)
 
         medians.append(median)
         sigmas.append(sigma)

--- a/empirical/GMM_models/meta_model.py
+++ b/empirical/GMM_models/meta_model.py
@@ -46,8 +46,6 @@ def meta_model(fault, site, im, weights_path=None, period=None, config=None, **k
     sigmas = []
 
     for gmm in models:
-        # if im == "pSA" and str(fault.tect_type) == "SUBDUCTION_SLAB":
-        #     breakpoint()
         if config is not None and gmm in config.keys():
             tmp_params_dict = config[gmm]
         else:
@@ -96,6 +94,4 @@ def meta_model(fault, site, im, weights_path=None, period=None, config=None, **k
     else:
         res = [(e_medians, (e_sigmas, sigma_average, sigma_intermodel))]
 
-    if not isinstance(res, list):
-        print(res)
     return res


### PR DESCRIPTION
# Fix the data type

## Updated on 24th November,
Those issues were found while plotting verification plots for IM vs Rrup which only has a single period value for pSA.

### `median = median[0] if isinstance(median, Iterable) else median` usage
For BCH_16 model, 
```python
sa_int = np.interp(np.log(period), np.log(periods_int), as)
```

This returns `ndarray` for this model [np.interp](https://numpy.org/doc/stable/reference/generated/numpy.interp.html), based on the doc, there are three different types of return? but its `ndarray` for our use case.
![Screenshot from 2021-11-24 16-29-48](https://user-images.githubusercontent.com/7849113/143170322-1f889d08-72e6-457c-ab91-57437e4cb458.png)
### This is what other models return 
![Screenshot from 2021-11-24 16-30-05](https://user-images.githubusercontent.com/7849113/143170331-b058c848-086c-41ed-89f0-15f191ccd515.png)

### `if len(res) == 1:  median, (sigma, _, _) = res[0]` usage
With BR_10 model, even if there is only one period for pSA, it still puts inside a list.
![Screenshot from 2021-11-24 16-31-29](https://user-images.githubusercontent.com/7849113/143170352-9f49598e-625f-4aca-99bf-0064680520ee.png)


## Previous description
During the verification plots process, noticed that the `medians` is a list of mixed data types.

Following parameters were used when this error was triggered.
`pSA` with `SUBDUCTION_SLAB`, 

![image (8)](https://user-images.githubusercontent.com/7849113/141715977-66a400f4-35cf-418e-b860-db7c297d3ef3.png)

With `np.log()` for `logmedians`, we get the following error message
```python
TypeError: loop of ufunc does not support argument 0 of type int which has no callable log method
```

For `logsigmas`, getting the following error message
```python
VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.
  return array(a, dtype, copy=False, order=order)
```

Adding the following lines to make sure to append float to `medians` instead of any other data type (E.g., list, tuple or np.ndarray)
```python
if isinstance(median, Iterable):
    median = median[0]
if isinstance(sigma, Iterable):
    sigma = sigma[0]
```