### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ PyYAML
 scipy==1.6
 matplotlib
 xlrd>=1.0.0
-git+https://github.com/gem/oq-engine.git#egg=openquake
+git+https://github.com/gem/oq-engine.git#egg=openquake-engine

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pytest>=3.5.0
 pytest-black
-numpy==1.19
+numpy
 numba>=0.48.0
 pandas==1.2
 PyYAML


### PR DESCRIPTION
# Update requirements

## Updating egg argument for openquake
![Screenshot from 2021-12-02 10-10-57](https://user-images.githubusercontent.com/7849113/144316348-57274b63-f214-47ca-a8f6-b76ce4fe58a3.png)

## Using the latest Numpy
![Screenshot from 2021-12-02 10-14-33](https://user-images.githubusercontent.com/7849113/144316434-3d7cc6b4-7ebb-4650-aa3a-e2e53f99e54e.png)

The latest Numba now supports the Numpy >= 1.20 - [Release Notes](https://numba.readthedocs.io/en/stable/release-notes.html)
![Screenshot from 2021-12-02 10-18-03](https://user-images.githubusercontent.com/7849113/144316546-e34d2616-149c-4458-a7f2-aff40235d70a.png)
![Screenshot from 2021-12-02 10-17-48](https://user-images.githubusercontent.com/7849113/144316560-3e18ec14-0a39-4aee-a342-39db47a47825.png)


