### PR TITLE
OpenQuake Wrapper for vectorized GMMs

### DIFF
--- a/empirical/GMM_models/Bradley_2010_Sa.py
+++ b/empirical/GMM_models/Bradley_2010_Sa.py
@@ -313,8 +313,6 @@ def B10(hw, m, rjb, rrup, rtvz, rx, vs30, z1p0, ztor, deltar, f_inferred, f_meas
     )
     # reference Sa on rock (Vs=1130m/s)
     Sa1130 = np.exp(term1 + term2 + term5 + term6 + term7 + term8 + term9 + term10)
-    # print("Similart to ln_y_ref?")
-    # breakpoint()
     # Modification 4: Rock amplification
     if period == 0:
         v1 = 1800
@@ -333,12 +331,9 @@ def B10(hw, m, rjb, rrup, rtvz, rx, vs30, z1p0, ztor, deltar, f_inferred, f_meas
             )
             * np.log((Sa1130 + phi4[i]) / phi4[i])
     )
-    # Check term13
     term13 = phi5[i] * (
             1.0 - 1.0 / np.cosh(phi6[i] * max(0, z1p0 - phi7[i]))
     ) + phi8[i] / np.cosh(0.15 * max(0, z1p0 - 15))
-    # print("Simliar to mean")
-    # breakpoint()
     # Compute median
     sa = np.exp(np.log(Sa1130) + term11 + term12 + term13)
     # Compute standard deviation
@@ -364,6 +359,5 @@ def compute_stdev(f_inferred, f_measured, m, sa_1130, vs30, i):
     sigma_inter = (1.0 + NL0) * tau  # 1
     sigma_intra = sigma  # 2
     sigma_SA = [sigma_total, sigma_inter, sigma_intra]
-    # breakpoint()
 
     return sigma_SA

--- a/empirical/GMM_models/Bradley_2010_Sa.py
+++ b/empirical/GMM_models/Bradley_2010_Sa.py
@@ -251,7 +251,7 @@ def calculate_Bradley(siteprop, faultprop, period):
     rjb = siteprop.Rjb
     rx = siteprop.Rx
     vs30 = siteprop.vs30
-    z10 = siteprop.z1p0 * 1000  # Convert from km to m
+    z10 = siteprop.z1p0  # Convert from km to m
     delta = faultprop.dip  # dip in degrees
     lambda_ = (
         faultprop.rake
@@ -313,6 +313,8 @@ def B10(hw, m, rjb, rrup, rtvz, rx, vs30, z1p0, ztor, deltar, f_inferred, f_meas
     )
     # reference Sa on rock (Vs=1130m/s)
     Sa1130 = np.exp(term1 + term2 + term5 + term6 + term7 + term8 + term9 + term10)
+    # print("Similart to ln_y_ref?")
+    # breakpoint()
     # Modification 4: Rock amplification
     if period == 0:
         v1 = 1800
@@ -331,9 +333,12 @@ def B10(hw, m, rjb, rrup, rtvz, rx, vs30, z1p0, ztor, deltar, f_inferred, f_meas
             )
             * np.log((Sa1130 + phi4[i]) / phi4[i])
     )
+    # Check term13
     term13 = phi5[i] * (
             1.0 - 1.0 / np.cosh(phi6[i] * max(0, z1p0 - phi7[i]))
     ) + phi8[i] / np.cosh(0.15 * max(0, z1p0 - 15))
+    # print("Simliar to mean")
+    # breakpoint()
     # Compute median
     sa = np.exp(np.log(Sa1130) + term11 + term12 + term13)
     # Compute standard deviation
@@ -359,5 +364,6 @@ def compute_stdev(f_inferred, f_measured, m, sa_1130, vs30, i):
     sigma_inter = (1.0 + NL0) * tau  # 1
     sigma_intra = sigma  # 2
     sigma_SA = [sigma_total, sigma_inter, sigma_intra]
+    # breakpoint()
 
     return sigma_SA

--- a/empirical/GMM_models/Bradley_2010_Sa.py
+++ b/empirical/GMM_models/Bradley_2010_Sa.py
@@ -251,7 +251,7 @@ def calculate_Bradley(siteprop, faultprop, period):
     rjb = siteprop.Rjb
     rx = siteprop.Rx
     vs30 = siteprop.vs30
-    z10 = siteprop.z1p0  # Convert from km to m
+    z10 = siteprop.z1p0 * 1000  # Convert from km to m
     delta = faultprop.dip  # dip in degrees
     lambda_ = (
         faultprop.rake

--- a/empirical/util/classdef.py
+++ b/empirical/util/classdef.py
@@ -175,5 +175,5 @@ def estimate_z2p5(z1p0=None, z1p5=None):
 
 def estimate_z1p0(vs30):
     return (
-        np.exp(28.5 - 3.82 / 8.0 * np.log(vs30 ** 8 + 378.7 ** 8)) / 1000.0
+        np.exp(28.5 - 3.82 / 8.0 * np.log(vs30**8 + 378.7**8)) / 1000.0
     )  # CY08 estimate in KM

--- a/empirical/util/classdef.py
+++ b/empirical/util/classdef.py
@@ -107,6 +107,7 @@ class GMM(ExtendedStrEnum):
     AG_20_NZ = 208, "AG20 (NZ)"
     Si_20 = 110, "S20 (NZ)"
     Z_16 = 111, "Z16"
+    Br_13 = 112, "Br13"
 
 
 class SiteClass(Enum):

--- a/empirical/util/classdef.py
+++ b/empirical/util/classdef.py
@@ -107,7 +107,6 @@ class GMM(ExtendedStrEnum):
     AG_20_NZ = 208, "AG20 (NZ)"
     Si_20 = 110, "S20 (NZ)"
     Z_16 = 111, "Z16"
-    Br_13 = 112, "Br13"
 
 
 class SiteClass(Enum):

--- a/empirical/util/empirical_factory.py
+++ b/empirical/util/empirical_factory.py
@@ -179,7 +179,7 @@ def compute_gmm(fault, site, gmm, im, period=None, gmm_param_config=None, **kwar
             site.Rtvz = 0
 
     if site.Rjb is None:
-        site.Rjb = np.sqrt(site.Rrup ** 2 - fault.ztor ** 2)
+        site.Rjb = np.sqrt(site.Rrup**2 - fault.ztor**2)
 
     if fault.Mw is None and gmm not in [GMM.SB_13]:
         print("Moment magnitude is a required parameter")

--- a/empirical/util/openquake_wrapper_vectorized.py
+++ b/empirical/util/openquake_wrapper_vectorized.py
@@ -124,19 +124,21 @@ def oq_mean_stddevs(model, ctx, imr, stddev_types):
     mean, stddevs = model.get_mean_and_stddevs(ctx, ctx, ctx, imr, stddev_types)
     mean_stddev_dict = {"mean": mean}
     for idx, std_dev in enumerate(stddev_types):
-        mean_stddev_dict[f"std_{std_dev}"] = stddevs[idx]
+        mean_stddev_dict[f"std_{std_dev.split()[0]}"] = stddevs[idx]
 
-    df = pd.DataFrame(mean_stddev_dict)
-    return df
+    return pd.DataFrame(mean_stddev_dict)
 
 
 def oq_run(model, rupture_df, im, period=None, **kwargs):
     """
-    Run an openquake model using Empirical_Engine input structures.
-    model: model or value from empirical.util.classdef.GMM or openquake class:
-           GMM.P_20 gsim.parker_2020.ParkerEtAl2020SInter
-    rupture_df: Rupture DF
-    site / fault: instances from empirical.classdef -- A tect_type must be able to be set to retrieve the correct model
+    Run an openquake model with dataframe
+    model: OQ models
+        Only support Bradley_2013 for now
+    rupture_df: Rupture DF and it's a single new-style context OQ uses
+        Columns for properties. E.g., vs30, z1pt0, rrup, rjb, mag, rake, dip....
+        Rows be the separate site-fault pairs
+        But Site information must be identical across the rows,
+        only the faults can be different
     im: intensity measure name
     period: for spectral acceleration, openquake tables automatically
             interpolate values between specified values, fails if outside range
@@ -160,7 +162,6 @@ def oq_run(model, rupture_df, im, period=None, **kwargs):
             ("vs30", rupture_df.vs30.values),
             ("z1pt0", rupture_df.z1pt0.values),
             ("z2pt5", rupture_df.z2pt5.values),
-            # Site itself, doesn't require vs30measured but needed for Rr_13
             ("vs30measured", rupture_df.vs30measured.values),
             # Distances
             ("rrup", rupture_df.rrup.values),

--- a/empirical/util/openquake_wrapper_vectorized.py
+++ b/empirical/util/openquake_wrapper_vectorized.py
@@ -77,6 +77,9 @@ def oq_run(model, rupture_df, im, period=None, **kwargs):
             "unknown distance property: " + " ".join(extra_dist_properties)
         )
 
+    """Hard coded for now but instead of having hard coded properties,
+    perhaps we can do loop over the DF's column values to create tuples dynamically?
+    """
     rupture_ctx = RuptureContext(
         (
             # Sites

--- a/empirical/util/openquake_wrapper_vectorized.py
+++ b/empirical/util/openquake_wrapper_vectorized.py
@@ -1,6 +1,5 @@
 """
-Wrapper for openquake models.
-Can import without openquake but using openquake models will raise ImportError.
+Wrapper for openquake vectorized models.
 
 Currently, focussing on implementing Bradley model only
 """

--- a/empirical/util/openquake_wrapper_vectorized.py
+++ b/empirical/util/openquake_wrapper_vectorized.py
@@ -104,7 +104,7 @@ def oq_run(
             [
                 # Openquake requiring occurrence_rate attribute to exist
                 ("occurrence_rate", None),
-                # sids is basically the number of sites provide
+                # sids is basically the number of sites provided
                 # each row of DF is site & rupture pair
                 ("sids", [None] * len(rupture_df.index)),
                 *(

--- a/empirical/util/openquake_wrapper_vectorized.py
+++ b/empirical/util/openquake_wrapper_vectorized.py
@@ -127,7 +127,10 @@ def oq_run(
                 # This term needs to be repeated for the number of rows in the df
                 ("sids", [1] * rupture_df.shape[0]),
                 *(
-                    (column, rupture_df.loc[:, column].values,)
+                    (
+                        column,
+                        rupture_df.loc[:, column].values,
+                    )
                     for column in rupture_df.columns.values
                 ),
             ]

--- a/empirical/util/openquake_wrapper_vectorized.py
+++ b/empirical/util/openquake_wrapper_vectorized.py
@@ -24,21 +24,16 @@ except ImportError:
     OQ = False
 
 # (oq_property name, ee_property_name)
-SITE_PROPERTIES = [
+CTX_PROPERTIES = [
     ("vs30", "vs30"),
     ("vs30measured", "vs30measured"),
     ("z1pt0", "z1p0"),
     ("z2pt5", "z2p5"),
-    ("fpeak", "fpeak"),
-]
-RUPTURE_PROPERTIES = [
     ("mag", "Mw"),
     ("rake", "rake"),
-    ("width", "width"),
+    ("dip", "dip"),
     ("ztor", "ztor"),
     ("hypo_depth", "hdepth"),
-]
-DISTANCE_PROPERTIES = [
     ("rrup", "Rrup"),
     ("rjb", "Rjb"),
     ("rx", "Rx"),
@@ -153,6 +148,27 @@ def oq_run(model, rupture_df, im, period=None, **kwargs):
     for st in [const.StdDev.TOTAL, const.StdDev.INTER_EVENT, const.StdDev.INTRA_EVENT]:
         if st in model.DEFINED_FOR_STANDARD_DEVIATION_TYPES:
             stddev_types.append(st)
+
+    # Check if df contains what we need
+    extra_site_parameters = set(model.REQUIRES_SITES_PARAMETERS).difference(
+        list(rupture_df.columns.values)
+    )
+    if len(extra_site_parameters) > 0:
+        raise ValueError("unknown site property: " + extra_site_parameters)
+
+    extra_rup_properties = set(model.REQUIRES_RUPTURE_PARAMETERS).difference(
+        list(rupture_df.columns.values)
+    )
+    if len(extra_rup_properties) > 0:
+        raise ValueError("unknown rupture property: " + " ".join(extra_rup_properties))
+
+    extra_dist_properties = set(model.REQUIRES_DISTANCES).difference(
+        list(rupture_df.columns.values)
+    )
+    if len(extra_dist_properties) > 0:
+        raise ValueError(
+            "unknown distance property: " + " ".join(extra_dist_properties)
+        )
 
     rupture = RuptureContext(
         (

--- a/empirical/util/openquake_wrapper_vectorized.py
+++ b/empirical/util/openquake_wrapper_vectorized.py
@@ -33,13 +33,13 @@ def oq_mean_stddevs(model, ctx, imr, stddev_types):
 def oq_run(model, rupture_df, im, period=None, **kwargs):
     """
     Run an openquake model with dataframe
-    model: OQ models
+    model: OQ model
         Only support Bradley_2013 for now
-    rupture_df: Rupture DF and it's a single new-style context OQ uses
+    rupture_df: Rupture DF
         Columns for properties. E.g., vs30, z1pt0, rrup, rjb, mag, rake, dip....
         Rows be the separate site-fault pairs
         But Site information must be identical across the rows,
-        only the faults can be different
+        only the faults can be different.
     im: intensity measure name
     period: for spectral acceleration, openquake tables automatically
             interpolate values between specified values, fails if outside range
@@ -55,21 +55,22 @@ def oq_run(model, rupture_df, im, period=None, **kwargs):
         if st in model.DEFINED_FOR_STANDARD_DEVIATION_TYPES:
             stddev_types.append(st)
 
-    # Check if df contains what we need
+    # Check if df contains what model requires
+    rupture_ctx_properties = list(rupture_df.columns.values)
     extra_site_parameters = set(model.REQUIRES_SITES_PARAMETERS).difference(
-        list(rupture_df.columns.values)
+        rupture_ctx_properties
     )
     if len(extra_site_parameters) > 0:
         raise ValueError("unknown site property: " + extra_site_parameters)
 
     extra_rup_properties = set(model.REQUIRES_RUPTURE_PARAMETERS).difference(
-        list(rupture_df.columns.values)
+        rupture_ctx_properties
     )
     if len(extra_rup_properties) > 0:
         raise ValueError("unknown rupture property: " + " ".join(extra_rup_properties))
 
     extra_dist_properties = set(model.REQUIRES_DISTANCES).difference(
-        list(rupture_df.columns.values)
+        rupture_ctx_properties
     )
     if len(extra_dist_properties) > 0:
         raise ValueError(

--- a/empirical/util/openquake_wrapper_vectorized.py
+++ b/empirical/util/openquake_wrapper_vectorized.py
@@ -1,0 +1,271 @@
+"""
+Wrapper for openquake models.
+Can import without openquake but using openquake models will raise ImportError.
+
+Currently, focussing on implementing Bradley model only
+"""
+from math import exp
+
+import numpy as np
+
+from empirical.util.classdef import TectType, GMM
+
+try:
+    # openquake constants and models
+    from openquake.hazardlib import const, imt, gsim
+    from openquake.hazardlib.site import Site, SiteCollection
+    from openquake.hazardlib.geo import Point
+
+    OQ = True
+except ImportError:
+    # fail silently, only an issue if openquake models wanted
+    OQ = False
+
+# (oq_property name, ee_property_name)
+SITE_PROPERTIES = [
+    ("vs30", "vs30"),
+    ("vs30measured", "vs30measured"),
+    ("z1pt0", "z1p0"),
+    ("z2pt5", "z2p5"),
+    ("fpeak", "fpeak"),
+]
+RUPTURE_PROPERTIES = [
+    ("mag", "Mw"),
+    ("rake", "rake"),
+    ("width", "width"),
+    ("ztor", "ztor"),
+    ("hypo_depth", "hdepth"),
+]
+DISTANCE_PROPERTIES = [
+    ("rrup", "Rrup"),
+    ("rjb", "Rjb"),
+    ("rx", "Rx"),
+    ("ry0", "Ry"),
+    ("rvolc", "Rtvz"),
+]
+
+OQ_GMM_LIST = [
+    GMM.P_20,
+    GMM.HA_20,
+    GMM.G_17,
+    GMM.BC_16,
+    GMM.S_16,
+    GMM.Ph_20,
+    GMM.Ch_20,
+    GMM.AG_20,
+    GMM.AG_20_NZ,
+    GMM.K_20,
+    GMM.K_20_NZ,
+    GMM.Si_20,
+    GMM.Z_16,
+    GMM.Br_13
+]
+if OQ:
+    oq_models = {
+        GMM.P_20: {
+            TectType.SUBDUCTION_SLAB: gsim.parker_2020.ParkerEtAl2020SSlab,
+            TectType.SUBDUCTION_INTERFACE: gsim.parker_2020.ParkerEtAl2020SInter,
+        },
+        GMM.HA_20: {
+            TectType.ACTIVE_SHALLOW: gsim.hassani_atkinson_2020.HassaniAtkinson2020Asc,
+            TectType.SUBDUCTION_SLAB: gsim.hassani_atkinson_2020.HassaniAtkinson2020SSlab,
+            TectType.SUBDUCTION_INTERFACE: gsim.hassani_atkinson_2020.HassaniAtkinson2020SInter,
+        },
+        GMM.G_17: {TectType.ACTIVE_SHALLOW: gsim.gulerce_2017.GulerceEtAl2017},
+        GMM.BC_16: {
+            TectType.ACTIVE_SHALLOW: gsim.bozorgnia_campbell_2016.BozorgniaCampbell2016
+        },
+        GMM.S_16: {TectType.ACTIVE_SHALLOW: gsim.stewart_2016_vh.StewartEtAl2016VH},
+        GMM.Ph_20: {
+            TectType.ACTIVE_SHALLOW: gsim.phung_2020.PhungEtAl2020Asc,
+            TectType.SUBDUCTION_SLAB: gsim.phung_2020.PhungEtAl2020SSlab,
+            TectType.SUBDUCTION_INTERFACE: gsim.phung_2020.PhungEtAl2020SInter,
+        },
+        GMM.Ch_20: {
+            TectType.ACTIVE_SHALLOW: gsim.chao_2020.ChaoEtAl2020Asc,
+            TectType.SUBDUCTION_SLAB: gsim.chao_2020.ChaoEtAl2020SSlab,
+            TectType.SUBDUCTION_INTERFACE: gsim.chao_2020.ChaoEtAl2020SInter,
+        },
+        GMM.AG_20: {
+            TectType.SUBDUCTION_SLAB: gsim.abrahamson_gulerce_2020.AbrahamsonGulerce2020SSlab,
+            TectType.SUBDUCTION_INTERFACE: gsim.abrahamson_gulerce_2020.AbrahamsonGulerce2020SInter,
+        },
+        GMM.AG_20_NZ: {
+            TectType.SUBDUCTION_SLAB: gsim.abrahamson_gulerce_2020.AbrahamsonGulerce2020SSlab,
+            TectType.SUBDUCTION_INTERFACE: gsim.abrahamson_gulerce_2020.AbrahamsonGulerce2020SInter,
+        },
+        GMM.K_20: {
+            TectType.SUBDUCTION_SLAB: gsim.kuehn_2020.KuehnEtAl2020SSlab,
+            TectType.SUBDUCTION_INTERFACE: gsim.kuehn_2020.KuehnEtAl2020SInter,
+        },
+        GMM.K_20_NZ: {
+            TectType.SUBDUCTION_SLAB: gsim.kuehn_2020.KuehnEtAl2020SSlab,
+            TectType.SUBDUCTION_INTERFACE: gsim.kuehn_2020.KuehnEtAl2020SInter,
+        },
+        GMM.Si_20: {
+            TectType.SUBDUCTION_SLAB: gsim.si_2020.SiEtAl2020SSlab,
+            TectType.SUBDUCTION_INTERFACE: gsim.si_2020.SiEtAl2020SInter,
+        },
+        GMM.Z_16: {
+            TectType.ACTIVE_SHALLOW: gsim.zhao_2016.ZhaoEtAl2016Asc,
+            TectType.SUBDUCTION_SLAB: gsim.zhao_2016.ZhaoEtAl2016SSlab,
+            TectType.SUBDUCTION_INTERFACE: gsim.zhao_2016.ZhaoEtAl2016SInter,
+        },
+        GMM.Br_13: {
+            TectType.ACTIVE_SHALLOW: gsim.bradley_2013.Bradley2013
+        }
+    }
+
+
+class Properties(object):
+    """
+    Stores values for sites, rup and dists.
+    """
+
+    def __init__(self):
+        # this allows attaching arbitrary attributes to self later
+        pass
+
+
+def oq_mean_stddevs(model, sites, rup, dists, imr, stddev_types):
+    """
+    Calculate mean and standard deviations given openquake input structures.
+    """
+    mean, stddevs = model.get_mean_and_stddevs(sites, rup, dists, imr, stddev_types)
+    mean = exp(mean[0]) if hasattr(mean, "__len__") else exp(mean)
+    stddevs = [s[0] if hasattr(s, "__len__") else s for s in stddevs]
+
+    return mean, stddevs
+
+
+def oq_run(model, site, fault, im, period=None, **kwargs):
+    """
+    Run an openquake model using Empirical_Engine input structures.
+    model: model or value from empirical.util.classdef.GMM or openquake class:
+           GMM.P_20 gsim.parker_2020.ParkerEtAl2020SInter
+    site / fault: instances from empirical.classdef -- A tect_type must be able to be set to retrieve the correct model
+    im: intensity measure name
+    period: for spectral acceleration, openquake tables automatically
+            interpolate values between specified values, fails if outside range
+    kwargs: pass extra (model specific) parameters to models
+    """
+    if not OQ:
+        raise ImportError("openquake is not installed, models not available")
+
+    # model can be given multiple ways
+    if type(model).__name__ == "GMM":
+        model = oq_models[model][fault.tect_type](**kwargs)
+    elif type(model).__name__ == "MetaGSIM":
+        model = model(**kwargs)
+
+    trt = model.DEFINED_FOR_TECTONIC_REGION_TYPE
+    if trt == const.TRT.SUBDUCTION_INTERFACE:
+        assert fault.tect_type == TectType.SUBDUCTION_INTERFACE
+    elif trt == const.TRT.SUBDUCTION_INTRASLAB:
+        assert fault.tect_type == TectType.SUBDUCTION_SLAB
+    elif trt == const.TRT.ACTIVE_SHALLOW_CRUST:
+        assert fault.tect_type == TectType.ACTIVE_SHALLOW
+    else:
+        raise ValueError("unknown tectonic region: " + trt)
+
+    stddev_types = []
+    for st in [const.StdDev.TOTAL, const.StdDev.INTER_EVENT, const.StdDev.INTRA_EVENT]:
+        if st in model.DEFINED_FOR_STANDARD_DEVIATION_TYPES:
+            stddev_types.append(st)
+
+    location = Point(
+        0.0, 0.0, 0.0
+    )  # Create a dummy location as OQ calculation doesn't use a location
+    oq_site = Site(location)
+    extra_site_parameters = set(model.REQUIRES_SITES_PARAMETERS).difference(
+        list(zip(*SITE_PROPERTIES))[0]
+    )
+    if len(extra_site_parameters) > 0:
+        raise ValueError("unknown site property: " + extra_site_parameters)
+    oq_site = check_properties(
+        site,
+        model,
+        model.REQUIRES_SITES_PARAMETERS,
+        SITE_PROPERTIES,
+        oq_site,
+        np_array=True,
+    )
+    if hasattr(oq_site, "z1pt0"):
+        oq_site.z1pt0 *= 1000
+
+    sites = SiteCollection([oq_site])
+
+    extra_rup_properties = set(model.REQUIRES_RUPTURE_PARAMETERS).difference(
+        list(zip(*RUPTURE_PROPERTIES))[0]
+    )
+    if len(extra_rup_properties) > 0:
+        raise ValueError("unknown rupture property: " + " ".join(extra_rup_properties))
+    rupture = check_properties(
+        fault,
+        model,
+        model.REQUIRES_RUPTURE_PARAMETERS,
+        RUPTURE_PROPERTIES,
+        Properties(),
+    )
+    # Openquake requiring occurrence_rate attribute to exist
+    rupture.occurrence_rate = None
+    extra_dist_properties = set(model.REQUIRES_DISTANCES).difference(
+        list(zip(*DISTANCE_PROPERTIES))[0]
+    )
+    if len(extra_dist_properties) > 0:
+        raise ValueError(
+            "unknown distance property: " + " ".join(extra_dist_properties)
+        )
+    dists = check_properties(
+        site,
+        model,
+        model.REQUIRES_DISTANCES,
+        DISTANCE_PROPERTIES,
+        Properties(),
+        np_array=True,
+    )
+
+    if period is not None:
+        assert imt.SA in model.DEFINED_FOR_INTENSITY_MEASURE_TYPES
+        # use sorted instead of max for full list
+        max_period = max([i.period for i in model.COEFFS.sa_coeffs.keys()])
+        single = False
+        if not hasattr(period, "__len__"):
+            single = True
+            period = [period]
+        results = []
+        for p in period:
+            imr = imt.SA(period=min(p, max_period))
+            m, s = oq_mean_stddevs(model, sites, rupture, dists, imr, stddev_types)
+            # interpolate pSA value up based on maximum available period
+            if p > max_period:
+                m = m * (max_period / p) ** 2
+            results.append((m, s))
+        if single:
+            return results[0]
+        return results
+    else:
+        imc = getattr(imt, im)
+        assert imc in model.DEFINED_FOR_INTENSITY_MEASURE_TYPES
+        return oq_mean_stddevs(model, sites, rupture, dists, imc(), stddev_types)
+
+
+def check_properties(
+    ee_object, model, model_requirements, properties, properties_obj, np_array=False
+):
+    for oq_property_name, ee_property_name in properties:
+        ee_property = getattr(ee_object, ee_property_name)
+        if ee_property is not None:
+            setattr(
+                properties_obj,
+                oq_property_name,
+                np.array([ee_property]) if np_array else ee_property,
+            )
+        else:
+            check_param(model_requirements, oq_property_name, model)
+    return properties_obj
+
+
+def check_param(model_requirements, rp, model):
+    if rp in model_requirements:
+        raise ValueError(f"{rp} is a required parameter for {model}")

--- a/empirical/util/openquake_wrapper_vectorized.py
+++ b/empirical/util/openquake_wrapper_vectorized.py
@@ -41,76 +41,6 @@ CTX_PROPERTIES = [
     ("rvolc", "Rtvz"),
 ]
 
-OQ_GMM_LIST = [
-    GMM.P_20,
-    GMM.HA_20,
-    GMM.G_17,
-    GMM.BC_16,
-    GMM.S_16,
-    GMM.Ph_20,
-    GMM.Ch_20,
-    GMM.AG_20,
-    GMM.AG_20_NZ,
-    GMM.K_20,
-    GMM.K_20_NZ,
-    GMM.Si_20,
-    GMM.Z_16,
-    GMM.Br_13,
-]
-if OQ:
-    oq_models = {
-        GMM.P_20: {
-            TectType.SUBDUCTION_SLAB: gsim.parker_2020.ParkerEtAl2020SSlab,
-            TectType.SUBDUCTION_INTERFACE: gsim.parker_2020.ParkerEtAl2020SInter,
-        },
-        GMM.HA_20: {
-            TectType.ACTIVE_SHALLOW: gsim.hassani_atkinson_2020.HassaniAtkinson2020Asc,
-            TectType.SUBDUCTION_SLAB: gsim.hassani_atkinson_2020.HassaniAtkinson2020SSlab,
-            TectType.SUBDUCTION_INTERFACE: gsim.hassani_atkinson_2020.HassaniAtkinson2020SInter,
-        },
-        GMM.G_17: {TectType.ACTIVE_SHALLOW: gsim.gulerce_2017.GulerceEtAl2017},
-        GMM.BC_16: {
-            TectType.ACTIVE_SHALLOW: gsim.bozorgnia_campbell_2016.BozorgniaCampbell2016
-        },
-        GMM.S_16: {TectType.ACTIVE_SHALLOW: gsim.stewart_2016_vh.StewartEtAl2016VH},
-        GMM.Ph_20: {
-            TectType.ACTIVE_SHALLOW: gsim.phung_2020.PhungEtAl2020Asc,
-            TectType.SUBDUCTION_SLAB: gsim.phung_2020.PhungEtAl2020SSlab,
-            TectType.SUBDUCTION_INTERFACE: gsim.phung_2020.PhungEtAl2020SInter,
-        },
-        GMM.Ch_20: {
-            TectType.ACTIVE_SHALLOW: gsim.chao_2020.ChaoEtAl2020Asc,
-            TectType.SUBDUCTION_SLAB: gsim.chao_2020.ChaoEtAl2020SSlab,
-            TectType.SUBDUCTION_INTERFACE: gsim.chao_2020.ChaoEtAl2020SInter,
-        },
-        GMM.AG_20: {
-            TectType.SUBDUCTION_SLAB: gsim.abrahamson_gulerce_2020.AbrahamsonGulerce2020SSlab,
-            TectType.SUBDUCTION_INTERFACE: gsim.abrahamson_gulerce_2020.AbrahamsonGulerce2020SInter,
-        },
-        GMM.AG_20_NZ: {
-            TectType.SUBDUCTION_SLAB: gsim.abrahamson_gulerce_2020.AbrahamsonGulerce2020SSlab,
-            TectType.SUBDUCTION_INTERFACE: gsim.abrahamson_gulerce_2020.AbrahamsonGulerce2020SInter,
-        },
-        GMM.K_20: {
-            TectType.SUBDUCTION_SLAB: gsim.kuehn_2020.KuehnEtAl2020SSlab,
-            TectType.SUBDUCTION_INTERFACE: gsim.kuehn_2020.KuehnEtAl2020SInter,
-        },
-        GMM.K_20_NZ: {
-            TectType.SUBDUCTION_SLAB: gsim.kuehn_2020.KuehnEtAl2020SSlab,
-            TectType.SUBDUCTION_INTERFACE: gsim.kuehn_2020.KuehnEtAl2020SInter,
-        },
-        GMM.Si_20: {
-            TectType.SUBDUCTION_SLAB: gsim.si_2020.SiEtAl2020SSlab,
-            TectType.SUBDUCTION_INTERFACE: gsim.si_2020.SiEtAl2020SInter,
-        },
-        GMM.Z_16: {
-            TectType.ACTIVE_SHALLOW: gsim.zhao_2016.ZhaoEtAl2016Asc,
-            TectType.SUBDUCTION_SLAB: gsim.zhao_2016.ZhaoEtAl2016SSlab,
-            TectType.SUBDUCTION_INTERFACE: gsim.zhao_2016.ZhaoEtAl2016SInter,
-        },
-        GMM.Br_13: {TectType.ACTIVE_SHALLOW: gsim.bradley_2013.Bradley2013},
-    }
-
 
 def oq_mean_stddevs(model, ctx, imr, stddev_types):
     """
@@ -175,21 +105,21 @@ def oq_run(model, rupture_df, im, period=None, **kwargs):
             # Sites
             # Create a dummy location as OQ calculation doesn't use a location
             ("location", Point(0.0, 0.0, 0.0)),
-            ("vs30", rupture_df.vs30.values),
-            ("z1pt0", rupture_df.z1pt0.values),
-            ("z2pt5", rupture_df.z2pt5.values),
-            ("vs30measured", rupture_df.vs30measured.values),
+            ("vs30", rupture_df.loc[:, "vs30"].values),
+            ("z1pt0", rupture_df.loc[:, "z1pt0"].values),
+            ("z2pt5", rupture_df.loc[:, "z2pt5"].values),
+            ("vs30measured", rupture_df.loc[:, "vs30measured"].values),
             # Distances
-            ("rrup", rupture_df.rrup.values),
-            ("rjb", rupture_df.rjb.values),
-            ("rx", rupture_df.rx.values),
-            ("rvolc", rupture_df.rvolc.values),
+            ("rrup", rupture_df.loc[:, "rrup"].values),
+            ("rjb", rupture_df.loc[:, "rjb"].values),
+            ("rx", rupture_df.loc[:, "rx"].values),
+            ("rvolc", rupture_df.loc[:, "rvolc"].values),
             # Rupture
-            ("mag", rupture_df.mag.values),
-            ("rake", rupture_df.rake.values),
-            ("dip", rupture_df.dip.values),
-            ("ztor", rupture_df.ztor.values),
-            ("hypo_depth", rupture_df.hypo_depth.values),
+            ("mag", rupture_df.loc[:, "mag"].values),
+            ("rake", rupture_df.loc[:, "rake"].values),
+            ("dip", rupture_df.loc[:, "dip"].values),
+            ("ztor", rupture_df.loc[:, "ztor"].values),
+            ("hypo_depth", rupture_df.loc[:, "hypo_depth"].values),
             # Openquake requiring occurrence_rate attribute to exist
             ("occurrence_rate", None),
         )
@@ -210,7 +140,9 @@ def oq_run(model, rupture_df, im, period=None, **kwargs):
             # interpolate pSA value up based on maximum available period
             if p > max_period:
                 result.update(
-                    pd.Series(result.get("mean") * (max_period / p) ** 2, name="mean")
+                    pd.Series(
+                        result.loc[:, "mean"] * (max_period / p) ** 2, name="mean"
+                    )
                 )
             results.append(result)
         if single:

--- a/empirical/util/openquake_wrapper_vectorized.py
+++ b/empirical/util/openquake_wrapper_vectorized.py
@@ -4,12 +4,7 @@ Can import without openquake but using openquake models will raise ImportError.
 
 Currently, focussing on implementing Bradley model only
 """
-from math import exp
-
-import numpy as np
 import pandas as pd
-
-from empirical.util.classdef import TectType, GMM
 
 try:
     # openquake constants and models
@@ -22,24 +17,6 @@ try:
 except ImportError:
     # fail silently, only an issue if openquake models wanted
     OQ = False
-
-# (oq_property name, ee_property_name)
-CTX_PROPERTIES = [
-    ("vs30", "vs30"),
-    ("vs30measured", "vs30measured"),
-    ("z1pt0", "z1p0"),
-    ("z2pt5", "z2p5"),
-    ("mag", "Mw"),
-    ("rake", "rake"),
-    ("dip", "dip"),
-    ("ztor", "ztor"),
-    ("hypo_depth", "hdepth"),
-    ("rrup", "Rrup"),
-    ("rjb", "Rjb"),
-    ("rx", "Rx"),
-    ("ry0", "Ry"),
-    ("rvolc", "Rtvz"),
-]
 
 
 def oq_mean_stddevs(model, ctx, imr, stddev_types):

--- a/empirical/util/openquake_wrapper_vectorized.py
+++ b/empirical/util/openquake_wrapper_vectorized.py
@@ -190,11 +190,13 @@ def oq_run(model, rupture_df, im, period=None, **kwargs):
         results = []
         for p in period:
             imr = imt.SA(period=min(p, max_period))
-            m, s = oq_mean_stddevs(model, rupture, imr, stddev_types)
+            result = oq_mean_stddevs(model, rupture, imr, stddev_types)
             # interpolate pSA value up based on maximum available period
             if p > max_period:
-                m = m * (max_period / p) ** 2
-            results.append((m, s))
+                result.update(
+                    pd.Series(result.get("mean") * (max_period / p) ** 2, name="mean")
+                )
+            results.append(result)
         if single:
             return results[0]
         return results

--- a/empirical/util/openquake_wrapper_vectorized.py
+++ b/empirical/util/openquake_wrapper_vectorized.py
@@ -105,21 +105,21 @@ def oq_run(model, rupture_df, im, period=None, **kwargs):
             # Sites
             # Create a dummy location as OQ calculation doesn't use a location
             ("location", Point(0.0, 0.0, 0.0)),
-            ("vs30", rupture_df.loc[:, "vs30"].values),
-            ("z1pt0", rupture_df.loc[:, "z1pt0"].values),
-            ("z2pt5", rupture_df.loc[:, "z2pt5"].values),
-            ("vs30measured", rupture_df.loc[:, "vs30measured"].values),
+            ("vs30", rupture_df.vs30.values),
+            ("z1pt0", rupture_df.z1pt0.values),
+            ("z2pt5", rupture_df.z2pt5.values),
+            ("vs30measured", rupture_df.vs30measured.values),
             # Distances
-            ("rrup", rupture_df.loc[:, "rrup"].values),
-            ("rjb", rupture_df.loc[:, "rjb"].values),
-            ("rx", rupture_df.loc[:, "rx"].values),
-            ("rvolc", rupture_df.loc[:, "rvolc"].values),
+            ("rrup", rupture_df.rrup.values),
+            ("rjb", rupture_df.rjb.values),
+            ("rx", rupture_df.rx.values),
+            ("rvolc", rupture_df.rvolc.values),
             # Rupture
-            ("mag", rupture_df.loc[:, "mag"].values),
-            ("rake", rupture_df.loc[:, "rake"].values),
-            ("dip", rupture_df.loc[:, "dip"].values),
-            ("ztor", rupture_df.loc[:, "ztor"].values),
-            ("hypo_depth", rupture_df.loc[:, "hypo_depth"].values),
+            ("mag", rupture_df.mag.values),
+            ("rake", rupture_df.rake.values),
+            ("dip", rupture_df.dip.values),
+            ("ztor", rupture_df.ztor.values),
+            ("hypo_depth", rupture_df.hypo_depth.values),
             # Openquake requiring occurrence_rate attribute to exist
             ("occurrence_rate", None),
         )
@@ -140,9 +140,7 @@ def oq_run(model, rupture_df, im, period=None, **kwargs):
             # interpolate pSA value up based on maximum available period
             if p > max_period:
                 result.update(
-                    pd.Series(
-                        result.loc[:, "mean"] * (max_period / p) ** 2, name="mean"
-                    )
+                    pd.Series(result.get("mean") * (max_period / p) ** 2, name="mean")
                 )
             results.append(result)
         if single:

--- a/empirical/util/openquake_wrapper_vectorized.py
+++ b/empirical/util/openquake_wrapper_vectorized.py
@@ -1,5 +1,5 @@
 """Wrapper for openquake vectorized models."""
-from typing import List
+from typing import Sequence
 
 import pandas as pd
 
@@ -20,27 +20,33 @@ OQ_MODELS = {
     "AG_20_NZ": gsim.kuehn_2020.KuehnEtAl2020SInter,
 }
 
+SPT_STD_DEVS = [const.StdDev.TOTAL, const.StdDev.INTER_EVENT, const.StdDev.INTRA_EVENT]
 
-def convert_im_label(im: imt):
+
+def convert_im_label(im: imt.IMT):
     """Convert OQ's SA(period) to the internal naming, pSA_period
-    im: imt
+    im: imt.IMT
     """
     imt_tuple = imt.imt2tup(im.string)
     return im if len(imt_tuple) == 1 else f"pSA_{imt_tuple[-1]}"
 
 
 def oq_mean_stddevs(
-    model: gsim, ctx: contexts.RuptureContext, im: imt, stddev_types: List
+    model: gsim.base.GMPE,
+    ctx: contexts.RuptureContext,
+    im: imt.IMT,
+    stddev_types: Sequence[const.StdDev],
 ):
     """Calculate mean and standard deviations given openquake input structures.
-    model: OQ Model
+    model: gsim.base.GMPE
+        OQ models we use are subclass of gsim.base.GMPE
     ctx: contexts.RuptureContext
         OQ RuptureContext that contains the following information
         - Site
         - Distance
         - Rupture
-    im: imt
-    stddev_types: List
+    im: imt.IMT
+    stddev_types: Sequence[const.StdDev]
     """
     mean, stddevs = model.get_mean_and_stddevs(ctx, ctx, ctx, im, stddev_types)
     mean_stddev_dict = {f"{convert_im_label(im)}_mean": mean}
@@ -53,19 +59,25 @@ def oq_mean_stddevs(
 
 
 def oq_run(
-    model: str, rupture_df: pd.DataFrame, im: str, period: List = None, **kwargs
+    model: str,
+    rupture_df: pd.DataFrame,
+    im: str,
+    period: Sequence[int] = None,
+    **kwargs,
 ):
     """Run an openquake model with dataframe
-    model: OQ model name, string
-        Only support Bradley_2013 for now
+    model: string
+        OQ model name
     rupture_df: Rupture DF
         Columns for properties. E.g., vs30, z1pt0, rrup, rjb, mag, rake, dip....
         Rows be the separate site-fault pairs
         But Site information must be identical across the rows,
         only the faults can be different.
-    im: intensity measure name
-    period: for spectral acceleration, openquake tables automatically
-            interpolate values between specified values, fails if outside range
+    im: string
+        intensity measure
+    period: Sequence[int]
+        for spectral acceleration, openquake tables automatically
+        interpolate values between specified values, fails if outside range
     kwargs: pass extra (model specific) parameters to models
     """
     model = (
@@ -74,13 +86,15 @@ def oq_run(
         else OQ_MODELS[model](region="NZL", **kwargs)
     )
 
-    stddev_types = []
-    for st in [const.StdDev.TOTAL, const.StdDev.INTER_EVENT, const.StdDev.INTRA_EVENT]:
-        if st in model.DEFINED_FOR_STANDARD_DEVIATION_TYPES:
-            stddev_types.append(st)
+    stddev_types = [
+        std for std in SPT_STD_DEVS if std in model.DEFINED_FOR_STANDARD_DEVIATION_TYPES
+    ]
+
+    # Make a copy in case the original rupture_df used with other functions
+    rupture_df = rupture_df.copy()
 
     # Check if df contains what model requires
-    rupture_ctx_properties = list(rupture_df.columns.values)
+    rupture_ctx_properties = set(rupture_df.columns.values)
     extra_site_parameters = set(model.REQUIRES_SITES_PARAMETERS).difference(
         rupture_ctx_properties
     )
@@ -101,22 +115,20 @@ def oq_run(
             "unknown distance property: " + " ".join(extra_dist_properties)
         )
 
-    # Make a copy in case the original rupture_df used with other functions
-    copied_rupture_df = rupture_df.copy()
     # Convert z1pt0 from km to m
-    copied_rupture_df["z1pt0"] *= 1000
+    rupture_df["z1pt0"] *= 1000
     # OQ's single new-style context which contains all site, distance and rupture's information
     rupture_ctx = contexts.RuptureContext(
         tuple(
             [
                 # Openquake requiring occurrence_rate attribute to exist
                 ("occurrence_rate", None),
-                # sids is basically the number of sites provided
-                # each row of DF is site & rupture pair
-                ("sids", [0] * len(rupture_df.index)),
+                # sids is the number of sites provided (OQ term)
+                # This term needs to be repeated for the number of rows in the df
+                ("sids", [1] * rupture_df.shape[0]),
                 *(
-                    (column, copied_rupture_df.loc[:, column].values,)
-                    for column in copied_rupture_df.columns.values
+                    (column, rupture_df.loc[:, column].values,)
+                    for column in rupture_df.columns.values
                 ),
             ]
         )

--- a/empirical/util/openquake_wrapper_vectorized.py
+++ b/empirical/util/openquake_wrapper_vectorized.py
@@ -15,7 +15,9 @@ OQ_MODELS = {
     "Z_06": gsim.zhao_2006.ZhaoEtAl2006Asc,
     "P_20": gsim.parker_2020.ParkerEtAl2020SInter,
     "K_20": gsim.abrahamson_gulerce_2020.AbrahamsonGulerce2020SInter,
+    "K_20_NZ": gsim.abrahamson_gulerce_2020.AbrahamsonGulerce2020SInter,
     "AG_20": gsim.kuehn_2020.KuehnEtAl2020SInter,
+    "AG_20_NZ": gsim.kuehn_2020.KuehnEtAl2020SInter,
 }
 
 
@@ -66,7 +68,11 @@ def oq_run(
             interpolate values between specified values, fails if outside range
     kwargs: pass extra (model specific) parameters to models
     """
-    model = OQ_MODELS[model](**kwargs)
+    model = (
+        OQ_MODELS[model](**kwargs)
+        if not model.endswith("_NZ")
+        else OQ_MODELS[model](region="NZL", **kwargs)
+    )
 
     stddev_types = []
     for st in [const.StdDev.TOTAL, const.StdDev.INTER_EVENT, const.StdDev.INTRA_EVENT]:


### PR DESCRIPTION
# OpenQuake Wrapper for vectorized GMMs

I am currently working on modifying some of the OQ's GMMs to support multiple faults at the same time and this is the new wrapper that can be used.

### Updates on 18/02/2022
1. `sids` with 0 instead of None as some models from OQ do not accept when it's None. (It actually happened with Br_13 so assuming they are more than just Br_13)
2. ZA_06 uses its own naming for `model.COEFFS` hence need to add a conditional statement.
3. OQ actually had a vectorized one for CB_14 so adding CB_14 as well.

The following scripts worked without any issues
```python
ctx_df = pd.read_csv(                                                    
    "/home/tom/Documents/QuakeCoRE/resource/oq_wrapper_df_inputs_10000_final.csv"
)                                                                        
                                                                         
for model in openquake_wrapper_vectorized.OQ_MODELS:                     
    br_1 = openquake_wrapper_vectorized.oq_run(model, ctx_df, "pSA", [0.05, 0.1, 4.0])
    br_2 = openquake_wrapper_vectorized.oq_run(model, ctx_df, "PGA")     
```

## What we wanted
1. Pass the DF to the wrapper
2. Wrapper reads DF and creates a useful object for OQ (GMM that supports multiple faults calculation)
    - I chose to use one class, `RuptureContext` and the reason behind this is, regardless of whether we pass one object, `RuptureContext` or three different objects, `SiteCollection`, `DistanceContext` and `RuptureContext` to OQ, OQ will combine this into one object with `RuptureContext` anyway. 
    ```python
    # from `gsim/base.py` in OQ
        if sites is not rup or dists is not rup:
            # convert three old-style contexts to a single new-style context
            ctx = full_context(sites, rup, dists)
        else:
            ctx = rup  # rup is already a good object

   def full_context(sites, rup, dctx=None):
    """
    :returns: a full RuptureContext with all the relevant attributes
    """
    self = RuptureContext()
    for par, val in vars(rup).items():
        setattr(self, par, val)
    if not hasattr(self, 'occurrence_rate'):
        self.occurrence_rate = numpy.nan
    if hasattr(sites, 'array'):  # is a SiteCollection
        for par in sites.array.dtype.names:
            setattr(self, par, sites[par])
    else:  # sites is a SitesContext
        for par, val in vars(sites).items():
            setattr(self, par, val)
    if dctx:
        for par, val in vars(dctx).items():
            setattr(self, par, val)
    return self
    ```
3. OQ returns a list of means, std_devs(Total, Inter and Intra)
4. The wrapper creates a DF with the OQ's return and returns it to us

## `oq_run` function takes a minimum of 3 arguments:
1. model - This is a Class
2. ctx_df - A `pd.DataFrame` that got created by reading a CSV
3. im - A string
4. period - list of periods if IM was pSA
5. kwargs - any extra if needed for a model class 

## What does ctx_df's CSV look like

As suggested, columns are properties and rows are site(with distance) and fault pairs.
For now(or even forever), site information must be identical across the rows whereas, fault data can be different.
(The image below shows the same faults but this was used to benchmark over 10,000 faults)
![image](https://user-images.githubusercontent.com/7849113/153291149-fa754ac5-e942-4918-bd5e-399840ad6051.png)

## How to get mean/std_devs with a new `oq_run`

```python
model = "Br_13"                               
ctx_df = pd.read_csv("/home/tom/Documents/QuakeCoRE/resource/oq_wrapper_df_inputs.csv")

# If IM was pSA
results = openquake_wrapper_vectorized.oq_run(model, ctx_df, "pSA", [0.01, 0.1, 4.0]) 
# If IM was PGA
results2 = openquake_wrapper_vectorized.oq_run(model, ctx_df, "PGA")     
```

`results` is a concatenated DF in `axis=1`
`results2` is a DF itself, as it's a single IM.

### What result looks like - where IM is pSA with three periods
![image](https://user-images.githubusercontent.com/7849113/153331524-c0039fcb-116e-4bab-9818-88447992a92c.png)


### What results2 looks like - where IM is PGA
![image](https://user-images.githubusercontent.com/7849113/153291861-1edc22a2-0c1c-45b8-bb76-347e4edb7df0.png)

## Performance/Benchmark
```python
# Calling OQ engine directly without reading DF
Vectorized job finished in 0.0022079944610595703
# For loop over a list of 10,000 faults
For loop, job finished in 1.8072998523712158
Vectorized one is 818.53x faster
# Comparing between vectorized and for loop
Checking means
True
Checking sigmas
True
True
True
# A new OQ Wrapper supports multiple faults
Comparison with openquake_wrapper_vectorized
OQ Wrapper job finished in 0.005442619323730469
Vector one is 2.46x faster
But OQ Wrapper is 332.06x faster than for loop.
# Comparing between vectorized and OQ Wrapper
Checking means
True
Checking sigmas
True
True
True
```
