### PR TITLE
Use contexts' method, get_mean_stds instead

### DIFF
--- a/empirical/util/openquake_wrapper_vectorized.py
+++ b/empirical/util/openquake_wrapper_vectorized.py
@@ -14,10 +14,10 @@ OQ_MODELS = {
     "CY_14": gsim.chiou_youngs_2014.ChiouYoungs2014,
     "Z_06": gsim.zhao_2006.ZhaoEtAl2006Asc,
     "P_20": gsim.parker_2020.ParkerEtAl2020SInter,
-    "K_20": gsim.abrahamson_gulerce_2020.AbrahamsonGulerce2020SInter,
-    "K_20_NZ": gsim.abrahamson_gulerce_2020.AbrahamsonGulerce2020SInter,
-    "AG_20": gsim.kuehn_2020.KuehnEtAl2020SInter,
-    "AG_20_NZ": gsim.kuehn_2020.KuehnEtAl2020SInter,
+    "K_20": gsim.kuehn_2020.KuehnEtAl2020SInter,
+    "K_20_NZ": gsim.kuehn_2020.KuehnEtAl2020SInter,
+    "AG_20": gsim.abrahamson_gulerce_2020.AbrahamsonGulerce2020SInter,
+    "AG_20_NZ": gsim.abrahamson_gulerce_2020.AbrahamsonGulerce2020SInter,
 }
 
 SPT_STD_DEVS = [const.StdDev.TOTAL, const.StdDev.INTER_EVENT, const.StdDev.INTRA_EVENT]
@@ -48,12 +48,17 @@ def oq_mean_stddevs(
     im: imt.IMT
     stddev_types: Sequence[const.StdDev]
     """
-    mean, stddevs = model.get_mean_and_stddevs(ctx, ctx, ctx, im, stddev_types)
-    mean_stddev_dict = {f"{convert_im_label(im)}_mean": mean}
+    # contexts.get_mean_stds returns ndarray, size of 4
+    # mean, std_total, std_inter and std_intra
+    # std_devs order may vary
+    results = contexts.get_mean_stds(model, ctx, [im])
+
+    mean_stddev_dict = {f"{convert_im_label(im)}_mean": results[0][0]}
     for idx, std_dev in enumerate(stddev_types):
-        mean_stddev_dict[f"{convert_im_label(im)}_std_{std_dev.split()[0]}"] = stddevs[
-            idx
-        ]
+        # std_devs are index between 1 and 3 from results
+        mean_stddev_dict[f"{convert_im_label(im)}_std_{std_dev.split()[0]}"] = results[
+            idx + 1
+        ][0]
 
     return pd.DataFrame(mean_stddev_dict)
 


### PR DESCRIPTION
# Use contexts' method, get_mean_stds instead
### Changes
- Fixed a typo
- Replace the compute method

Refer to this [PR feedback](https://github.com/gem/oq-engine/pull/7665#issuecomment-1074853831)

We had to replace this new method to make the Kuehn model works.
(Our mags is an array with N >= 1 elements this wont work with [mag] = something as something is N >= size)

Hence, our wrapper now uses `contexts.get_mean_stds()`

Some of you might worry about using idx + 1
At least all the models we use via OQ, they all have three different std_devs, so it is fine for now.
But, whenever the model we decide to use, less than 3 std_devs, may causing an issue as `contexts.get_mean_stds()` will always return 4 items, mean and (std_total, std_inter, std_intra) <- std order may vary on the model but less likely), so if the model only has std_inter, `contexts.get_mean_stds()` returns something like
```python
[ [mean], [0], [std_inter], [0] ]
```
Then the idx from the following code block is only 0 because model A only had std_inter, so `stddev_types` is ["std_inter"], then results[0 + 1] is supposed to be a `std_total` not `std_inter`. But again, it's not an issue for now.
(As stddev_types is the filtered array by comparing with each model's `DEFINED_FOR_STANDARD_DEVIATION_TYPES`).

```python
    for idx, std_dev in enumerate(stddev_types):
        # std_devs are index between 1 and 3 from results
        mean_stddev_dict[f"{convert_im_label(im)}_std_{std_dev.split()[0]}"] = results[
            idx + 1
        ][0]
```

They are identical between wrapper and calling `contexts.get_mean_stds()` directly.
![image](https://user-images.githubusercontent.com/7849113/159611434-86ad0ca0-bad6-40a4-9420-d63fdab2ccba.png)
