### PR TITLE
OQ ZA_06 interpolation and extrapolation

### DIFF
--- a/empirical/util/openquake_wrapper_vectorized.py
+++ b/empirical/util/openquake_wrapper_vectorized.py
@@ -251,9 +251,7 @@ def oq_run(
             ]
         )
         max_period = max(avail_periods)
-        single = False
         if not hasattr(periods, "__len__"):
-            single = True
             periods = [periods]
         results = []
         for period in periods:
@@ -282,8 +280,7 @@ def oq_run(
                     * (max_period / period) ** 2
                 )
             results.append(result)
-        if single:
-            return results[0]
+
         return pd.concat(results, axis=1)
     else:
         imc = getattr(imt, im)

--- a/empirical/util/openquake_wrapper_vectorized.py
+++ b/empirical/util/openquake_wrapper_vectorized.py
@@ -223,7 +223,10 @@ def oq_run(
                 # This term needs to be repeated for the number of rows in the df
                 ("sids", [1] * rupture_df.shape[0]),
                 *(
-                    (column, rupture_df.loc[:, column].values,)
+                    (
+                        column,
+                        rupture_df.loc[:, column].values,
+                    )
                     for column in rupture_df.columns.values
                 ),
             ]

--- a/empirical/util/openquake_wrapper_vectorized.py
+++ b/empirical/util/openquake_wrapper_vectorized.py
@@ -133,9 +133,9 @@ def interpolate_to_closest(
     return pd.DataFrame(
         {
             f"pSA_{period}_mean": np.log(mean(period)),
-            f"pSA_{period}_std_Total": np.log(sigma_total(period)),
-            f"pSA_{period}_std_Inter": np.log(sigma_inter(period)),
-            f"pSA_{period}_std_Intra": np.log(sigma_intra(period)),
+            f"pSA_{period}_std_Total": sigma_total(period),
+            f"pSA_{period}_std_Inter": sigma_inter(period),
+            f"pSA_{period}_std_Intra": sigma_intra(period),
         }
     )
 

--- a/empirical/util/openquake_wrapper_vectorized.py
+++ b/empirical/util/openquake_wrapper_vectorized.py
@@ -91,8 +91,7 @@ def oq_mean_stddevs(
 def interpolate_to_closest(
     period: Union[float, int], x: np.ndarray, low_y: pd.DataFrame, high_y: pd.DataFrame
 ):
-    """
-    Use interpolation to find the value of new points at the given period.
+    """Use interpolation to find the value of new points at the given period.
 
     period: Union[float, int]
         target period for interpolation

--- a/empirical/util/openquake_wrapper_vectorized.py
+++ b/empirical/util/openquake_wrapper_vectorized.py
@@ -108,20 +108,20 @@ def interpolate_to_closest(
 
     # Create new DFs by columns from low_y and high_y
     mean_df = pd.DataFrame().assign(
-        low=low_y.loc[:, low_y.columns.str.endswith("mean")].iloc[:, 0],
-        high=high_y.loc[:, high_y.columns.str.endswith("mean")].iloc[:, 0],
+        low=np.exp(low_y.loc[:, low_y.columns.str.endswith("mean")].iloc[:, 0]),
+        high=np.exp(high_y.loc[:, high_y.columns.str.endswith("mean")].iloc[:, 0]),
     )
     sigma_total_df = pd.DataFrame().assign(
-        low=low_y.loc[:, low_y.columns.str.endswith("std_Total")].iloc[:, 0],
-        high=high_y.loc[:, high_y.columns.str.endswith("std_Total")].iloc[:, 0],
+        low=np.exp(low_y.loc[:, low_y.columns.str.endswith("std_Total")].iloc[:, 0]),
+        high=np.exp(high_y.loc[:, high_y.columns.str.endswith("std_Total")].iloc[:, 0]),
     )
     sigma_inter_df = pd.DataFrame().assign(
-        low=low_y.loc[:, low_y.columns.str.endswith("std_Inter")].iloc[:, 0],
-        high=high_y.loc[:, high_y.columns.str.endswith("std_Inter")].iloc[:, 0],
+        low=np.exp(low_y.loc[:, low_y.columns.str.endswith("std_Inter")].iloc[:, 0]),
+        high=np.exp(high_y.loc[:, high_y.columns.str.endswith("std_Inter")].iloc[:, 0]),
     )
     sigma_intra_df = pd.DataFrame().assign(
-        low=low_y.loc[:, low_y.columns.str.endswith("std_Intra")].iloc[:, 0],
-        high=high_y.loc[:, high_y.columns.str.endswith("std_Intra")].iloc[:, 0],
+        low=np.exp(low_y.loc[:, low_y.columns.str.endswith("std_Intra")].iloc[:, 0]),
+        high=np.exp(high_y.loc[:, high_y.columns.str.endswith("std_Intra")].iloc[:, 0]),
     )
 
     # Create interpolation functions
@@ -132,10 +132,10 @@ def interpolate_to_closest(
 
     return pd.DataFrame(
         {
-            f"pSA_{period}_mean": mean(period),
-            f"pSA_{period}_std_Total": sigma_total(period),
-            f"pSA_{period}_std_Inter": sigma_inter(period),
-            f"pSA_{period}_std_Intra": sigma_intra(period),
+            f"pSA_{period}_mean": np.log(mean(period)),
+            f"pSA_{period}_std_Total": np.log(sigma_total(period)),
+            f"pSA_{period}_std_Inter": np.log(sigma_inter(period)),
+            f"pSA_{period}_std_Intra": np.log(sigma_intra(period)),
         }
     )
 
@@ -278,10 +278,9 @@ def oq_run(
 
             # extrapolate pSA value up based on maximum available period
             if period > max_period:
-                result.update(
-                    pd.Series(
-                        result.get("mean") * (max_period / period) ** 2, name="mean"
-                    )
+                result.loc[:, result.columns.str.endswith("mean")] = np.log(
+                    np.exp(result.loc[:, result.columns.str.endswith("mean")])
+                    * (max_period / period) ** 2
                 )
             results.append(result)
         if single:


### PR DESCRIPTION
# OQ ZA_06 interpolation and extrapolation

## Updates on 2nd of May.

- stddevs interpolation no longer needs `np.exp`
- Simplified the extrapolation's calculation, thanks to James. 
- Implemented catch for KeyError(where most likely the invalid period for OQ that needs interpolation) and any other exceptions we don't/can't handle.

### mean and stddevs are matching between OQ and EE implementations
![image](https://user-images.githubusercontent.com/7849113/166183274-02063b0e-808a-48d5-b194-aededfc7babb.png)
![image](https://user-images.githubusercontent.com/7849113/166183292-1a19325a-4acf-4c11-ae30-b82db6b2a0e2.png)
![image](https://user-images.githubusercontent.com/7849113/166183301-d9a35d46-58cc-41d0-a08b-3ef9896c848d.png)
![image](https://user-images.githubusercontent.com/7849113/166183308-af696693-bb0a-4fff-a3e5-f53813413dcb.png)
![image](https://user-images.githubusercontent.com/7849113/166183320-00f6bd40-89dd-46b9-86e4-57710cf36bd0.png)


## This interpolation is based on the way we have within EE.
Unfortunately, I don't think we can implement the OQ way of interpolating due to the issue with `math.log(max_below.period)`, which is equivalent to `math.log(0.0)` in our use case to interpolate between 0.0 and 0.05.
(Most cases, `self.logratio` is True)
```python
if self.logratio:  # regular case
    # ratio tends to 1 when target period tends to a minimum
    # known period above and to 0 if target period is close
    # to maximum period below.
    ratio = ((math.log(imt.period) - math.log(max_below.period)) /
             (math.log(min_above.period) - math.log(max_below.period)))
else:  # in the ACME project
    ratio = ((imt.period - max_below.period) /
             (min_above.period - max_below.period))
below = self.sa_coeffs[max_below]
above = self.sa_coeffs[min_above]
lst = [(above[n] - below[n]) * ratio + below[n] for n in self.rb.names]
self._coeffs[imt] = c = self.rb(*lst)
```

## Interpolation where periods < 0.05
![Screenshot from 2022-04-29 16-10-14](https://user-images.githubusercontent.com/7849113/165885000-e34f7798-d1cd-4a0b-a2c8-388460012a06.png)

## Extrapolation where periods > 5.0
![Screenshot from 2022-04-29 16-10-26](https://user-images.githubusercontent.com/7849113/165885013-7d1ec960-970e-4924-9d26-3bb12a7eed38.png)

## In case you wonder about the way I implemented the interpolation
Convert with `np.exp`, then convert back with `np.log`

### For stddevs, no longer applying `np.exp`
```python
mean_df = pd.DataFrame().assign(
        low=np.exp(low_y.loc[:, low_y.columns.str.endswith("mean")].iloc[:, 0]),
        high=np.exp(high_y.loc[:, high_y.columns.str.endswith("mean")].iloc[:, 0]),
    )
    sigma_total_df = pd.DataFrame().assign(
        low=np.exp(low_y.loc[:, low_y.columns.str.endswith("std_Total")].iloc[:, 0]),
        high=np.exp(high_y.loc[:, high_y.columns.str.endswith("std_Total")].iloc[:, 0]),
    )
    sigma_inter_df = pd.DataFrame().assign(
        low=np.exp(low_y.loc[:, low_y.columns.str.endswith("std_Inter")].iloc[:, 0]),
        high=np.exp(high_y.loc[:, high_y.columns.str.endswith("std_Inter")].iloc[:, 0]),
    )
    sigma_intra_df = pd.DataFrame().assign(
        low=np.exp(low_y.loc[:, low_y.columns.str.endswith("std_Intra")].iloc[:, 0]),
        high=np.exp(high_y.loc[:, high_y.columns.str.endswith("std_Intra")].iloc[:, 0]),
    )

return pd.DataFrame(
        {
            f"pSA_{period}_mean": np.log(mean(period)),
            f"pSA_{period}_std_Total": np.log(sigma_total(period)),
            f"pSA_{period}_std_Inter": np.log(sigma_inter(period)),
            f"pSA_{period}_std_Intra": np.log(sigma_intra(period)),
        }
    )
```

I believe that the logarithmic functions are the inverses of exponential functions.

However, some interpolations aren't quite identical/close enough without approaching the above.

![Screenshot from 2022-04-29 16-11-58](https://user-images.githubusercontent.com/7849113/165885362-ebd6ff9c-53ac-43c8-a183-d2ae0cc9fd75.png)

OQ returns in the form of a logarithm(?) where EE returns in exponential. Hence when we compare values between EE and OQ, we had to apply `np.log()` to EE values.

Hence, to match the way EE is implemented, apply `np.exp` then apply `np.log` again to get logarithm values.



