### PR TITLE
Support more models to work with META config

### DIFF
--- a/empirical/util/openquake_wrapper_vectorized.py
+++ b/empirical/util/openquake_wrapper_vectorized.py
@@ -244,8 +244,8 @@ def oq_run(
             ]
         )
 
-        # Perform dot products
-        return meta_results.dot(pd.Series(meta_config.values()))
+        # Compute the weighted average
+        return np.sum(meta_results * pd.Series(meta_config.values()))
 
     model = OQ_MODELS[model_type][tect_type](**kwargs)
 

--- a/empirical/util/openquake_wrapper_vectorized.py
+++ b/empirical/util/openquake_wrapper_vectorized.py
@@ -372,8 +372,13 @@ def oq_run(
             )
 
         elif model.name == "BCH_16":
+            # Equivalent to classdef.Site's backarc and the default value we set is False
+            # Within OQ, they use either 0 or 1
             if "xvf" not in rupture_df:
-                rupture_df["xvf"] = 1
+                rupture_df["xvf"] = 0
+            # abrahamson_2015 uses dists = rrup for SUBDUCTION_INTERFACE
+            # or dists = rhypo for SUBDUCTION_SLAB. Hence, I believe we can use rrup
+            # Also, internal bc_hydro_2016 script uses rrup
             if "rhypo" not in rupture_df:
                 rupture_df["rhypo"] = rupture_df["rrup"]
 
@@ -418,7 +423,10 @@ def oq_run(
                 # This term needs to be repeated for the number of rows in the df
                 ("sids", [1] * rupture_df.shape[0]),
                 *(
-                    (column, rupture_df.loc[:, column].values,)
+                    (
+                        column,
+                        rupture_df.loc[:, column].values,
+                    )
                     for column in rupture_df.columns.values
                 ),
             ]

--- a/empirical/util/openquake_wrapper_vectorized.py
+++ b/empirical/util/openquake_wrapper_vectorized.py
@@ -27,6 +27,10 @@ OQ_MODELS = {
     GMM.Br_10: {TectType.ACTIVE_SHALLOW: gsim.bradley_2013.Bradley2013},
     GMM.ASK_14: {TectType.ACTIVE_SHALLOW: gsim.abrahamson_2014.AbrahamsonEtAl2014},
     GMM.AS_16: {TectType.ACTIVE_SHALLOW: gsim.afshari_stewart_2016.AfshariStewart2016},
+    GMM.A_18: {
+        TectType.SUBDUCTION_SLAB: gsim.abrahamson_2018.AbrahamsonEtAl2018SSlab,
+        TectType.SUBDUCTION_INTERFACE: gsim.abrahamson_2018.AbrahamsonEtAl2018SInter,
+    },
     # OQ's CB_08 includes the CB_10's CAV
     GMM.CB_10: {
         TectType.ACTIVE_SHALLOW: gsim.campbell_bozorgnia_2008.CampbellBozorgnia2008
@@ -37,6 +41,10 @@ OQ_MODELS = {
             model=gsim.campbell_bozorgnia_2014.CampbellBozorgnia2014,
             estimate_width=True,
         )
+    },
+    GMM.BCH_16: {
+        TectType.SUBDUCTION_SLAB: gsim.bchydro_2016_epistemic.BCHydroESHM20SSlab,
+        TectType.SUBDUCTION_INTERFACE: gsim.bchydro_2016_epistemic.BCHydroESHM20SInter,
     },
     GMM.BSSA_14: {TectType.ACTIVE_SHALLOW: gsim.boore_2014.BooreEtAl2014},
     GMM.CY_14: {TectType.ACTIVE_SHALLOW: gsim.chiou_youngs_2014.ChiouYoungs2014},
@@ -254,6 +262,12 @@ def oq_run(
         rupture_df["width"] = estimations.estimate_width_ASK14(
             rupture_df["dip"], rupture_df["mag"]
         )
+
+    elif model_type.name == "BCH_16":
+        if "xvf" not in rupture_df:
+            rupture_df["xvf"] = 1
+        if "rhypo" not in rupture_df:
+            rupture_df["rhypo"] = rupture_df["rrup"]
 
     # Rename to OQ's term
     if im in ("Ds575", "Ds595"):

--- a/empirical/util/openquake_wrapper_vectorized.py
+++ b/empirical/util/openquake_wrapper_vectorized.py
@@ -1,5 +1,4 @@
 """Wrapper for openquake vectorized models."""
-import multiprocessing as mp
 import logging
 from typing import Sequence, Union, Dict, List
 from functools import partial
@@ -92,8 +91,10 @@ SPT_STD_DEVS = [const.StdDev.TOTAL, const.StdDev.INTER_EVENT, const.StdDev.INTRA
 
 
 def meta_dot_products(models_dfs: List[pd.DataFrame], weights: List):
+    # Copy onf ot the DFs to perform dot products
     meta_df = models_dfs[0].copy()
 
+    # Perform the dot products over each column
     for column in meta_df.columns:
         col_df = pd.DataFrame([model_df[column].values for model_df in models_dfs]).T
         meta_df[column] = col_df.dot(pd.Series(weights)).values

--- a/empirical/util/openquake_wrapper_vectorized.py
+++ b/empirical/util/openquake_wrapper_vectorized.py
@@ -217,87 +217,6 @@ def interpolate_with_pga(
     )
 
 
-def compute_oq_gmm(periods, idx, model, im, rupture_ctx, stddev_types):
-    if periods is not None:
-        assert imt.SA in model.DEFINED_FOR_INTENSITY_MEASURE_TYPES
-        # use sorted instead of max for full list
-        avail_periods = np.asarray(
-            [
-                im.period
-                for im in (
-                    model.COEFFS.sa_coeffs.keys()
-                    if not isinstance(
-                        model,
-                        (
-                            gsim.zhao_2006.ZhaoEtAl2006Asc,
-                            gsim.zhao_2006.ZhaoEtAl2006SSlab,
-                            gsim.zhao_2006.ZhaoEtAl2006SInter,
-                        ),
-                    )
-                    else model.COEFFS_ASC.sa_coeffs.keys()
-                )
-            ]
-        )
-        max_period = max(avail_periods)
-        if not hasattr(periods, "__len__"):
-            periods = [periods]
-        results = []
-        for period in periods:
-            im = imt.SA(period=min(period, max_period))
-            try:
-                result = oq_mean_stddevs(model, rupture_ctx, im, stddev_types[idx])
-            except KeyError as ke:
-                cause = ke.args[0]
-                # To make sure the KeyError is about missing pSA's period
-                if (
-                    isinstance(cause, imt.IMT)
-                    and str(cause).startswith("SA")
-                    and cause.period > 0.0
-                ):
-                    # Period is smaller than model's supported min_period E.g., ZA_06
-                    # Interpolate between PGA(0.0) and model's min_period
-                    low_result = oq_mean_stddevs(
-                        model, rupture_ctx, imt.PGA(), stddev_types[idx]
-                    )
-                    high_period = avail_periods[period <= avail_periods][0]
-                    high_result = oq_mean_stddevs(
-                        model,
-                        rupture_ctx,
-                        imt.SA(period=high_period),
-                        stddev_types[idx],
-                    )
-
-                    result = interpolate_with_pga(
-                        period, high_period, low_result, high_result
-                    )
-                else:
-                    # KeyError that we cannot handle
-                    logging.exception(ke)
-                    raise
-            except Exception as e:
-                # Any other exceptions that we cannot handle
-                logging.exception(e)
-                raise
-
-            # extrapolate pSA value up based on maximum available period
-            if period > max_period:
-                result.loc[:, result.columns.str.endswith("mean")] += 2 * np.log(
-                    max_period / period
-                )
-                # Updating the period from max_period to the given period
-                # E.g with ZA_06, replace 5.0 to period > 5.0
-                result.columns = result.columns.str.replace(
-                    str(max_period), str(period), regex=False
-                )
-            results.append(result)
-
-        return pd.concat(results, axis=1)
-    else:
-        imc = getattr(imt, im)
-        assert imc in model.DEFINED_FOR_INTENSITY_MEASURE_TYPES
-        return oq_mean_stddevs(model, rupture_ctx, imc(), stddev_types[idx])
-
-
 def oq_run(
     model_type: GMM,
     tect_type: TectType,
@@ -433,96 +352,88 @@ def oq_run(
         )
     )
 
-    # final_results = []
-    with mp.Pool(processes=5) as pool:
-        final_results = pool.starmap(
-            compute_oq_gmm,
-            [
-                (periods, idx, model, im, rupture_ctx, stddev_types)
-                for idx, model in enumerate(models)
-            ],
-        )
-    # for idx, model in enumerate(models):
-    #     if periods is not None:
-    #         assert imt.SA in model.DEFINED_FOR_INTENSITY_MEASURE_TYPES
-    #         # use sorted instead of max for full list
-    #         avail_periods = np.asarray(
-    #             [
-    #                 im.period
-    #                 for im in (
-    #                     model.COEFFS.sa_coeffs.keys()
-    #                     if not isinstance(
-    #                         model,
-    #                         (
-    #                             gsim.zhao_2006.ZhaoEtAl2006Asc,
-    #                             gsim.zhao_2006.ZhaoEtAl2006SSlab,
-    #                             gsim.zhao_2006.ZhaoEtAl2006SInter,
-    #                         ),
-    #                     )
-    #                     else model.COEFFS_ASC.sa_coeffs.keys()
-    #                 )
-    #             ]
-    #         )
-    #         max_period = max(avail_periods)
-    #         if not hasattr(periods, "__len__"):
-    #             periods = [periods]
-    #         results = []
-    #         for period in periods:
-    #             im = imt.SA(period=min(period, max_period))
-    #             try:
-    #                 result = oq_mean_stddevs(model, rupture_ctx, im, stddev_types[idx])
-    #             except KeyError as ke:
-    #                 cause = ke.args[0]
-    #                 # To make sure the KeyError is about missing pSA's period
-    #                 if (
-    #                     isinstance(cause, imt.IMT)
-    #                     and str(cause).startswith("SA")
-    #                     and cause.period > 0.0
-    #                 ):
-    #                     # Period is smaller than model's supported min_period E.g., ZA_06
-    #                     # Interpolate between PGA(0.0) and model's min_period
-    #                     low_result = oq_mean_stddevs(
-    #                         model, rupture_ctx, imt.PGA(), stddev_types[idx]
-    #                     )
-    #                     high_period = avail_periods[period <= avail_periods][0]
-    #                     high_result = oq_mean_stddevs(
-    #                         model,
-    #                         rupture_ctx,
-    #                         imt.SA(period=high_period),
-    #                         stddev_types[idx],
-    #                     )
-    #
-    #                     result = interpolate_with_pga(
-    #                         period, high_period, low_result, high_result
-    #                     )
-    #                 else:
-    #                     # KeyError that we cannot handle
-    #                     logging.exception(ke)
-    #                     raise
-    #             except Exception as e:
-    #                 # Any other exceptions that we cannot handle
-    #                 logging.exception(e)
-    #                 raise
-    #
-    #             # extrapolate pSA value up based on maximum available period
-    #             if period > max_period:
-    #                 result.loc[:, result.columns.str.endswith("mean")] += 2 * np.log(
-    #                     max_period / period
-    #                 )
-    #                 # Updating the period from max_period to the given period
-    #                 # E.g with ZA_06, replace 5.0 to period > 5.0
-    #                 result.columns = result.columns.str.replace(
-    #                     str(max_period), str(period), regex=False
-    #                 )
-    #             results.append(result)
-    #
-    #         final_results.append(pd.concat(results, axis=1))
-    #     else:
-    #         imc = getattr(imt, im)
-    #         assert imc in model.DEFINED_FOR_INTENSITY_MEASURE_TYPES
-    #         final_results.append(
-    #             oq_mean_stddevs(model, rupture_ctx, imc(), stddev_types[idx])
-    #         )
+    final_results = []
+    for idx, model in enumerate(models):
+        if periods is not None:
+            assert imt.SA in model.DEFINED_FOR_INTENSITY_MEASURE_TYPES
+            # use sorted instead of max for full list
+            avail_periods = np.asarray(
+                [
+                    im.period
+                    for im in (
+                        model.COEFFS.sa_coeffs.keys()
+                        if not isinstance(
+                            model,
+                            (
+                                gsim.zhao_2006.ZhaoEtAl2006Asc,
+                                gsim.zhao_2006.ZhaoEtAl2006SSlab,
+                                gsim.zhao_2006.ZhaoEtAl2006SInter,
+                            ),
+                        )
+                        else model.COEFFS_ASC.sa_coeffs.keys()
+                    )
+                ]
+            )
+            max_period = max(avail_periods)
+            if not hasattr(periods, "__len__"):
+                periods = [periods]
+            results = []
+            for period in periods:
+                im = imt.SA(period=min(period, max_period))
+                try:
+                    result = oq_mean_stddevs(model, rupture_ctx, im, stddev_types[idx])
+                except KeyError as ke:
+                    cause = ke.args[0]
+                    # To make sure the KeyError is about missing pSA's period
+                    if (
+                        isinstance(cause, imt.IMT)
+                        and str(cause).startswith("SA")
+                        and cause.period > 0.0
+                    ):
+                        # Period is smaller than model's supported min_period E.g., ZA_06
+                        # Interpolate between PGA(0.0) and model's min_period
+                        low_result = oq_mean_stddevs(
+                            model, rupture_ctx, imt.PGA(), stddev_types[idx]
+                        )
+                        high_period = avail_periods[period <= avail_periods][0]
+                        high_result = oq_mean_stddevs(
+                            model,
+                            rupture_ctx,
+                            imt.SA(period=high_period),
+                            stddev_types[idx],
+                        )
+
+                        result = interpolate_with_pga(
+                            period, high_period, low_result, high_result
+                        )
+                    else:
+                        # KeyError that we cannot handle
+                        logging.exception(ke)
+                        raise
+                except Exception as e:
+                    # Any other exceptions that we cannot handle
+                    logging.exception(e)
+                    raise
+
+                # extrapolate pSA value up based on maximum available period
+                if period > max_period:
+                    result.loc[:, result.columns.str.endswith("mean")] += 2 * np.log(
+                        max_period / period
+                    )
+                    # Updating the period from max_period to the given period
+                    # E.g with ZA_06, replace 5.0 to period > 5.0
+                    result.columns = result.columns.str.replace(
+                        str(max_period), str(period), regex=False
+                    )
+                results.append(result)
+
+            final_results.append(pd.concat(results, axis=1))
+        else:
+            imc = getattr(imt, im)
+            assert imc in model.DEFINED_FOR_INTENSITY_MEASURE_TYPES
+            final_results.append(
+                oq_mean_stddevs(model, rupture_ctx, imc(), stddev_types[idx])
+            )
 
     return (
         final_results[0]


### PR DESCRIPTION
# Support more models to work with META config

## Updates on 9/8/2022 regarding dot-products


Adopt the A_18 and BCH_16 from OpenQuake to compute with the current META weights.

`meta_df` is basically the old version of dot-products I implemented(loop through to allocate each column)
They seem to be identical with a newer approach.
![image](https://user-images.githubusercontent.com/7849113/183546397-cc12dd44-c767-4cf2-8ab5-29a85bdc62d3.png)

There are two extra variables the BCH_16 requires:
1. `xvf`
2. `rhypo`
I also left comments but `xvf`, we set it to False by default, and for `rhypo`, OQ uses either `rhypo` or `rrup` whether it's a SUBDUCTION_SLAB or SUBDUCTION_INTERFACE, so I think I can just pass `rrup`? (Unless we have a specific value, rhypo)

### Regarding the `xvf`
This is what we have, which is called `backarc`
![image](https://user-images.githubusercontent.com/7849113/182749564-3910c05f-7158-4841-b7d6-b16ed14d360f.png)

Which I believe is equivalent to the following part - https://github.com/gem/oq-engine/blob/master/openquake/hazardlib/gsim/bchydro_2016_epistemic.py#L28

If `xvf` is passed, they create a `np.zeros(length)` and then change it to 1 accordingly (https://github.com/gem/oq-engine/blob/master/openquake/hazardlib/gsim/bchydro_2016_epistemic.py#L58)

## Example
###OQ with BC_Hydro

https://github.com/gem/oq-engine/blob/master/openquake/hazardlib/gsim/abrahamson_2015.py#L137
![image](https://user-images.githubusercontent.com/7849113/182750215-411588b2-a813-49bf-abd3-4453498bd62d.png)

and that `faba_model` is
https://github.com/gem/oq-engine/blob/master/openquake/hazardlib/gsim/bchydro_2016_epistemic.py#L28
![image](https://user-images.githubusercontent.com/7849113/182750491-f75f5e8c-5b7e-41b3-9447-9261defc8a10.png)

### EE BC_Hydro
![image](https://user-images.githubusercontent.com/7849113/182750363-d2a7eb0e-dc2b-4521-aff3-c65d1abd2b8b.png)
https://github.com/ucgmsim/Empirical_Engine/blob/master/empirical/GMM_models/bc_hydro_2016_subduction.py#L120




Based on the following meta weights config:

```python
!!python/tuple [pSA, PGA]:
        ACTIVE_SHALLOW:
                Br_10: 0.2
                ASK_14: 0.2
                BSSA_14: 0.2
                CB_14: 0.2
                CY_14: 0.2
        SUBDUCTION_INTERFACE:
                ZA_06: 0.1
                BCH_16: 0.05
                A_18: 0.1
                P_20: 0.3
                AG_20: 0.075
                AG_20_NZ: 0.075
                K_20: 0.1
                K_20_NZ: 0.2
        SUBDUCTION_SLAB:
                ZA_06: 0.1
                BCH_16: 0.05
                A_18: 0.1
                P_20: 0.2
                AG_20: 0.1
                AG_20_NZ: 0.1
                K_20: 0.175
                K_20_NZ: 0.175
        VOLCANIC:
                Br_10: 1.0
PGV:
        ACTIVE_SHALLOW:
                ASK_14: 0.25
                BSSA_14: 0.25
                CB_14: 0.25
                CY_14: 0.25
        SUBDUCTION_INTERFACE:
                P_20: 0.5
                K_20: 0.25
                K_20_NZ: 0.25
        SUBDUCTION_SLAB:
                P_20: 0.32
                K_20: 0.34
                K_20_NZ: 0.34
        VOLCANIC:
                Br_10: 1.0
```