### PR TITLE
Support for Type-5 avg strike, dip rake for GMPE calculations

### DIFF
--- a/empirical/util/estimations.py
+++ b/empirical/util/estimations.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pandas as pd
 
+from source_modelling.sources import Plane
+
 
 def estimate_width_ASK14(dip: pd.Series, mag: pd.Series):
     """Estimate a width for ASK_14 model
@@ -9,3 +11,45 @@ def estimate_width_ASK14(dip: pd.Series, mag: pd.Series):
     mag: pd.Series
     """
     return np.minimum(18 / np.sin(np.radians(dip)), 10 ** (-1.75 + 0.45 * mag))
+
+
+def calculate_avg_strike_dip_rake(planes: list[Plane], plane_avg_rake: list[float], plane_total_slip: list[float]):
+    """
+    Calculates the average strike, dip and rake of the fault planes
+    based on the weighted average of the Total Slip on each plane.
+    Useful when taking into account multiple fault planes and trying to calculate
+    a single strike, dip and rake for the fault/scenario.
+
+    Parameters
+    ----------
+    planes : list[Plane]
+        List of Plane objects
+    plane_avg_rake : list[float]
+        List of the average rake of the fault planes
+    plane_total_slip : list[float]
+        List of the total slip on each fault plane
+
+    Returns
+    -------
+    avg_strike : float
+        Average strike of the fault planes
+    avg_dip : float
+        Average dip of the fault planes
+    avg_rake : float
+        Average rake of the fault planes
+    """
+    # Calculate the weights based on the total slip on each plane
+    slip_weights = np.asarray(plane_total_slip) / sum(plane_total_slip)
+
+    # Compute the weighted average of the strike, dip and rake
+    avg_strike = np.average(
+        [plane.strike for plane in planes], weights=slip_weights
+    )
+    avg_dip = np.average(
+        [plane.dip for plane in planes], weights=slip_weights
+    )
+    avg_rake = np.average(
+        plane_avg_rake, weights=slip_weights
+    )
+
+    return avg_strike, avg_dip, avg_rake

--- a/empirical/util/estimations.py
+++ b/empirical/util/estimations.py
@@ -13,7 +13,9 @@ def estimate_width_ASK14(dip: pd.Series, mag: pd.Series):
     return np.minimum(18 / np.sin(np.radians(dip)), 10 ** (-1.75 + 0.45 * mag))
 
 
-def calculate_avg_strike_dip_rake(planes: list[Plane], plane_avg_rake: list[float], plane_total_slip: list[float]):
+def calculate_avg_strike_dip_rake(
+    planes: list[Plane], plane_avg_rake: list[float], plane_total_slip: list[float]
+):
     """
     Calculates the average strike, dip and rake of the fault planes
     based on the weighted average of the Total Slip on each plane.
@@ -42,14 +44,8 @@ def calculate_avg_strike_dip_rake(planes: list[Plane], plane_avg_rake: list[floa
     slip_weights = np.asarray(plane_total_slip) / sum(plane_total_slip)
 
     # Compute the weighted average of the strike, dip and rake
-    avg_strike = np.average(
-        [plane.strike for plane in planes], weights=slip_weights
-    )
-    avg_dip = np.average(
-        [plane.dip for plane in planes], weights=slip_weights
-    )
-    avg_rake = np.average(
-        plane_avg_rake, weights=slip_weights
-    )
+    avg_strike = np.average([plane.strike for plane in planes], weights=slip_weights)
+    avg_dip = np.average([plane.dip for plane in planes], weights=slip_weights)
+    avg_rake = np.average(plane_avg_rake, weights=slip_weights)
 
     return avg_strike, avg_dip, avg_rake

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ bottleneck>=1.3.4
 pandas
 scipy>=1.7.2
 git+https://github.com/gem/oq-engine.git#egg=openquake-engine
+source-modelling @ git+https://github.com/ucgmsim/source_modelling.git


### PR DESCRIPTION
Does a weighted average based on the Total slip for each plane
Adds source_modelling to Empirical_Engine

Placed here and using Plane class so that you dont need an SRF to calculate these and can be the same process in NZGMDB as well as Empirical calculations when needed.