### PR TITLE
chore: downgrade numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 geojson
 h5py
 mera @ git+https://github.com/ucgmsim/mera.git
-numpy
+numpy<2
 openquake.engine
 pandas
 pytest-black


### PR DESCRIPTION
Fixes a bug in openquake (it allows numpy > 2 to be installed but doesn't work with it).