### PR TITLE
BCH16 test fix

### DIFF
--- a/oq_wrapper/wrapper.py
+++ b/oq_wrapper/wrapper.py
@@ -666,6 +666,12 @@ def get_oq_model(
     ):
         kwargs = {**kwargs, **epis_mapping[epistemic_branch]}
 
+    # Prior to OQ 3.25 "Step" was default however,
+    # it was changed to None, which causes issues.
+    # See https://github.com/gem/oq-engine/pull/11312
+    if model is constants.GMM.BCH_16:
+        kwargs["faba_taper_model"] = "Step"
+
     oq_model = OQ_MODEL_MAPPING[model][tect_type](**kwargs)
 
     if (

--- a/tests/test_gmm_benchmark.py
+++ b/tests/test_gmm_benchmark.py
@@ -10,12 +10,6 @@ import oq_wrapper as oqw
 
 DATA_DIR = Path(__file__).parent / "benchmark_data"
 RUPTURE_PATH = DATA_DIR / "nzgmdb_v4p3_rupture_df.parquet"
-SKIPPED_TESTS = {
-    (
-        "BCH_16|NHM2010_BB",
-        "SUBDUCTION_",
-    ): "Backarc calculation broken upstream in version 3.25+"
-}
 
 
 def pytest_generate_tests(metafunc: Metafunc) -> None:
@@ -27,24 +21,9 @@ def pytest_generate_tests(metafunc: Metafunc) -> None:
         for f in files:
             gmm_name, tect_raw = f.stem.split("TectType")
             gmm_name = gmm_name.strip("_")
-            tect_name = tect_raw.strip("_")
 
             test_id = f"{f.parent.name}/{f.stem}"
-
-            skip_reason = None
-            for (gmm_pat, tect_pat), reason in SKIPPED_TESTS.items():
-                if re.search(gmm_pat, gmm_name) and re.search(tect_pat, tect_name):
-                    skip_reason = reason
-                    break
-
-            if skip_reason:
-                params.append(
-                    pytest.param(
-                        f, marks=pytest.mark.skip(reason=skip_reason), id=test_id
-                    )
-                )
-            else:
-                params.append(pytest.param(f, id=test_id))
+            params.append(pytest.param(f, id=test_id))
 
         metafunc.parametrize("benchmark_ffp", params)
 

--- a/tests/test_gmm_benchmark.py
+++ b/tests/test_gmm_benchmark.py
@@ -1,4 +1,3 @@
-import re
 from pathlib import Path
 
 import pandas as pd
@@ -19,9 +18,6 @@ def pytest_generate_tests(metafunc: Metafunc) -> None:
 
         params = []
         for f in files:
-            gmm_name, tect_raw = f.stem.split("TectType")
-            gmm_name = gmm_name.strip("_")
-
             test_id = f"{f.parent.name}/{f.stem}"
             params.append(pytest.param(f, id=test_id))
 


### PR DESCRIPTION
Fix the BCH 16 models usage.

See https://github.com/gem/oq-engine/pull/11312#issuecomment-4086052654 for explanation.