### PR TITLE
Add xarray interface for openquake wrapper

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,3 +28,4 @@ jobs:
       - name: Run tests
         run: |
           uv run --extra test pytest tests
+          uv run --extra test pytest --doctest-modules oq_wrapper

--- a/oq_wrapper/wrapper.py
+++ b/oq_wrapper/wrapper.py
@@ -1053,13 +1053,23 @@ def _convert_from_oq_im(im: imt.IMT) -> str:
     str
         Converted IM label
 
-    Notes
-    -----
-    Examples of conversions:
-    - EAS(frequency) → EAS_frequency
-    - SA(period) → pSA_period
-    - RSD575 → Ds575
-    - RSD595 → Ds595
+    Examples
+    --------
+    >>> im = imt.EAS(frequency=5.0)
+    >>> _convert_from_oq_im(im)
+    'EAS_5.0'
+
+    >>> im = imt.SA(period=1.0)
+    >>> _convert_from_oq_im(im)
+    'pSA_1.0'
+
+    >>> im = imt.RSD575()
+    >>> _convert_from_oq_im(im)
+    'Ds575'
+
+    >>> im = imt.PGA()
+    >>> _convert_from_oq_im(im)
+    'PGA'
     """
     if im[0].startswith("EAS"):
         period = im[1]

--- a/oq_wrapper/xarray.py
+++ b/oq_wrapper/xarray.py
@@ -164,8 +164,9 @@ def run_gmm_xarray(
     ['model', 'period', 'station']
 
     >>> # Get the mean for model 'd' and 'a_10' at 1.0s.
-    >>> psa['mean'].sel(station='a_10', model='d').sel(period=1.0, method='nearest').item()
-    ...
+    >>> result = psa['mean'].sel(station='a_10', model='d').sel(period=1.0, method='nearest').item()
+    >>> isinstance(result, float)
+    True
 
     See Also
     --------
@@ -277,8 +278,9 @@ def run_gmm_logic_tree_xarray(
     ['model', 'period', 'station']
 
     >>> # Get the mean for model 'd' and 'a_10' at 1.0s.
-    >>> psa['mean'].sel(station='a_10', model='d').sel(period=1.0, method='nearest').item()
-    ...
+    >>> result = psa['mean'].sel(station='a_10', model='d').sel(period=1.0, method='nearest').item()
+    >>> isinstance(result, float)
+    True
 
     See Also
     --------

--- a/oq_wrapper/xarray.py
+++ b/oq_wrapper/xarray.py
@@ -1,0 +1,279 @@
+"""Xarray interface for running OpenQuake Ground Motion Models and Logic Trees."""
+
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+import re
+
+from . import constants, run_gmm_logic_tree
+from .wrapper import run_gmm
+
+GENERAL_RX = re.compile(
+    r"""
+    (?P<im>[^_]+)               # Capture group 'im': Matches one or more characters 
+                                # that are NOT an underscore (stops at first '_')
+    
+    (?:                         # Start of a non-capturing group for the optional value
+        _                       # A literal underscore separator
+        (?P<val>[\d\.]+)        # Capture group 'val': Matches digits or periods
+    )?                          # The '?' makes the entire '_value' portion optional
+    
+    _                           # A literal underscore separator before the statistic
+    
+    (?P<statistic>.+)           # Capture group 'statistic': Matches everything else 
+                                # to the end of the string
+    """,
+    re.VERBOSE,
+)
+
+
+def _pack_dataset(
+    results: pd.DataFrame,
+) -> xr.Dataset:
+    """Pack the results of run_gmm(_logic_tree) into a multi-dimensional dataset.
+
+    Parameters
+    ----------
+    results : pd.DataFrame
+        The results of run_gmm(_logic_tree).
+
+    Returns
+    -------
+    Dataset
+        A multi-dimensional dataset extracted the dataframe, analysing the
+        columns to extract the intensity measure, period and frequency.
+    """
+    test_column = results.columns[0]
+    extracted = results.columns.str.extract(GENERAL_RX)
+    levels = ["im"]
+
+    match (match := GENERAL_RX.match(test_column)) and match.groupdict():
+        case {"im": "pSA"}:
+            extracted = extracted.rename(columns=dict(val="period"))
+            extracted["period"] = pd.to_numeric(extracted["period"])
+            levels.append("period")
+        case {"im": "EAS"}:
+            extracted = extracted.rename(columns=dict(val="frequency"))
+            extracted["frequency"] = pd.to_numeric(extracted["frequency"])
+            levels.append("frequency")
+        case None:
+            raise ValueError(
+                f"Could not extract dimensions for test column: {test_column!r}"
+            )
+        case _:
+            extracted = extracted.drop("val", axis="columns")
+
+    results.columns = pd.MultiIndex.from_frame(extracted)
+    results = results.stack(level=levels)  # ty: ignore[invalid-assignment]
+    im_name = match.group("im")
+
+    dset = results.to_xarray()
+    dset = dset.sel(im=im_name, drop=True)
+    dset.attrs["intensity_measure"] = im_name
+
+    return dset
+
+
+def run_gmm_xarray(
+    model: constants.GMM,
+    tect_type: constants.TectType,
+    inputs: xr.Dataset,
+    im: str,
+    periods: Sequence[float | int] | None = None,
+    frequencies: Sequence[float | int] | None = None,
+    epistemic_branch: constants.EpistemicBranch = constants.EpistemicBranch.CENTRAL,
+    **kwargs: Any,
+) -> xr.Dataset:
+    """
+    Run OpenQuake GMM for the given xarray dataset and intensity measure.
+
+    Parameters
+    ----------
+    model : constants.GMM
+        Ground motion model identifier
+    tect_type : constants.TectType
+        Tectonic type
+    inputs : xr.Dataset
+        Xarray dataset containing variables like vs30, rrup, mag.
+        Dimensions do not need to match natively; they will be broadcast together.
+    im : str
+        Intensity measure (e.g., 'PGA', 'pSA', 'EAS')
+    periods : Sequence[float | int], optional
+        Periods to compute for pSA
+    frequencies : Sequence[float | int], optional
+        Frequencies to compute for EAS
+    epistemic_branch : constants.EpistemicBranch
+        Epistemic branch mapping
+
+    Returns
+    -------
+    xr.Dataset
+        A Dataset containing the GMM results. Statistics (mean, std_Total, etc.)
+        are stored as data variables. The intensity measure type is stored
+        in the global attributes.
+
+    Examples
+    --------
+    >>> import oq_wrapper as oqw
+    >>> import oq_wrapper.xarray as oqwx
+    >>> import xarray as xr
+    >>> import numpy as np
+
+    >>> # Create a dataset with heterogeneous dimensions:
+    >>> # rrup (station), vs30 (model, station), and mag (scalar)
+    >>> rng = np.random.default_rng(seed=0)
+    >>> inputs = xr.Dataset(
+    ...     data_vars=dict(
+    ...         rrup=('station', np.linspace(1, 100, num=10)),
+    ...         vs30=(('model', 'station'), rng.uniform(500, 1500, size=(5, 10))),
+    ...         mag=8.3
+    ...     ),
+    ...     coords=dict(
+    ...         station=[f'a_{i}' for i in range(1, 11)],
+    ...         model=['a', 'b', 'c', 'd', 'e']
+    ...     )
+    ... )
+
+    >>> # Run the GMM across the entire dimension grid
+    >>> psa = oqwx.run_gmm_xarray(
+    ...     oqw.constants.GMM.A_22,
+    ...     oqw.constants.TectType.ACTIVE_SHALLOW,
+    ...     inputs,
+    ...     'pSA',
+    ...     periods=[1.0, 5.0]
+    ... )
+
+    >>> # Statistics become data variables
+    >>> sorted(psa)
+    ['mean', 'std_Inter', 'std_Intra', 'std_Total']
+
+    >>> # Input dimensions are broadcast with periods (or frequencies).
+    >>> sorted(psa.coords.keys())
+    ['model', 'period', 'station']
+
+    >>> # Get the mean for model 'd' and 'a_32' at 1.0.
+    >>> # psa.sel(station='a_32', model='d').sel(period=1.0, method='nearest').item()
+
+    See Also
+    --------
+    run_gmm : The lower level wrapper function for pandas dataframes.
+    """
+    rupture_df = inputs.to_dataframe()
+
+    df_result = run_gmm(
+        model=model,
+        tect_type=tect_type,
+        rupture_df=rupture_df,
+        im=im,
+        periods=periods,
+        frequencies=frequencies,
+        epistemic_branch=epistemic_branch,
+        **kwargs,
+    )
+
+    return _pack_dataset(df_result)
+
+
+def run_gmm_logic_tree_xarray(
+    gmm_lt: constants.GMMLogicTree,
+    tect_type: constants.TectType,
+    inputs: xr.Dataset,
+    im: str,
+    periods: Sequence[float | int] | None = None,
+    **kwargs: Any,
+) -> xr.Dataset:
+    """
+    Run OpenQuake GMM Logic Tree for the given xarray dataset and intensity measure.
+
+    Parameters
+    ----------
+    gmm_lt : constants.GMMLogicTree
+        Ground motion model logic tree identifier
+    tect_type : constants.TectType
+        Tectonic type
+    inputs : xr.Dataset
+        Xarray dataset containing variables like vs30, rrup, mag.
+        Dimensions do not need to match natively; they will be broadcast together.
+    im : str
+        Intensity measure (e.g., 'PGA', 'pSA', 'EAS')
+    periods : Sequence[float | int], optional
+        Periods to compute for pSA
+
+    Returns
+    -------
+    xr.Dataset
+        A Dataset containing the GMM results. Statistics (mean, std_Total)
+        are stored as data variables. The intensity measure type is stored
+        in the global attributes.
+
+    Examples
+    --------
+    >>> import oq_wrapper as oqw
+    >>> import oq_wrapper.xarray as oqwx
+    >>> import xarray as xr
+    >>> import numpy as np
+
+    >>> rng = np.random.default_rng(seed=0)
+    >>> inputs = xr.Dataset(
+    ...     dict(
+    ...         rrup=("station", np.linspace(1, 100, num=10)),
+    ...         rjb=("station", rng.uniform(1, 100, size=(10,))),
+    ...         rx=("station", rng.uniform(1, 100, size=(10,))),
+    ...         ry=("station", rng.uniform(1, 100, size=(10,))),
+    ...         hyp=("station", rng.uniform(1, 100, size=(10,))),
+    ...         epi=("station", rng.uniform(1, 100, size=(10,))),
+    ...         ztor=0.0,
+    ...         dip=60.0,
+    ...         rake=15.0,
+    ...         hypo_depth=5.0,
+    ...         zbot=10.0,
+    ...         vs30measured=False,
+    ...         vs30=(("model", "station"), rng.uniform(500, 1500, size=(5, 10))),
+    ...         z1pt0=(("model", "station"), rng.uniform(0.5, 1.5, size=(5, 10))),
+    ...         z2pt5=(("model", "station"), rng.uniform(0.5, 1.5, size=(5, 10))),
+    ...         mag=8.3,
+    ...     ),
+    ...     coords=dict(
+    ...         station=[f"a_{i}" for i in range(1, 11)], model=["a", "b", "c", "d", "e"]
+    ...     ),
+    ... )
+
+    >>> # Run a Logic Tree
+    >>> psa = oqwx.run_gmm_logic_tree_xarray(
+    ...     oqw.constants.GMMLogicTree.NSHM2022,
+    ...     oqw.constants.TectType.ACTIVE_SHALLOW,
+    ...     inputs,
+    ...     'pSA',
+    ...     periods=list(np.linspace(1, 10, 50))
+    ... )
+
+    >>> # Statistics become data variables
+    >>> sorted(psa)
+    ['mean', 'std_Total']
+
+    >>> # Input dimensions are broadcast with periods (or frequencies).
+    >>> sorted(psa.coords.keys())
+    ['model', 'period', 'station']
+
+    >>> # Get the mean for model 'd' and 'a_32' at 1.0.
+    >>> # psa.sel(station='a_32', model='d').sel(period=1.0, method='nearest').item()
+
+    See Also
+    --------
+    run_gmm_logic_tree : The lower level wrapper function for pandas dataframes.
+    """
+    rupture_df = inputs.to_dataframe()
+
+    df_result = run_gmm_logic_tree(
+        gmm_lt,
+        tect_type=tect_type,
+        rupture_df=rupture_df,
+        im=im,
+        periods=periods,
+        **kwargs,
+    )
+
+    return _pack_dataset(df_result)

--- a/oq_wrapper/xarray.py
+++ b/oq_wrapper/xarray.py
@@ -154,8 +154,9 @@ def run_gmm_xarray(
     >>> sorted(psa.coords.keys())
     ['model', 'period', 'station']
 
-    >>> # Get the mean for model 'd' and 'a_32' at 1.0.
-    >>> # psa.sel(station='a_32', model='d').sel(period=1.0, method='nearest').item()
+    >>> # Get the mean for model 'd' and 'a_32' at 1.0s.
+    >>> psa['mean'].sel(station='a_32', model='d').sel(period=1.0, method='nearest').item()
+    ...
 
     See Also
     --------
@@ -258,8 +259,9 @@ def run_gmm_logic_tree_xarray(
     >>> sorted(psa.coords.keys())
     ['model', 'period', 'station']
 
-    >>> # Get the mean for model 'd' and 'a_32' at 1.0.
-    >>> # psa.sel(station='a_32', model='d').sel(period=1.0, method='nearest').item()
+    >>> # Get the mean for model 'd' and 'a_32' at 1.0s.
+    >>> psa['mean'].sel(station='a_32', model='d').sel(period=1.0, method='nearest').item()
+    ...
 
     See Also
     --------

--- a/oq_wrapper/xarray.py
+++ b/oq_wrapper/xarray.py
@@ -1,15 +1,13 @@
 """Xarray interface for running OpenQuake Ground Motion Models and Logic Trees."""
 
+import re
 from collections.abc import Sequence
 from typing import Any
 
-import numpy as np
 import pandas as pd
 import xarray as xr
-import re
 
-from . import constants, run_gmm_logic_tree
-from .wrapper import run_gmm
+from . import constants, wrapper
 
 GENERAL_RX = re.compile(
     r"""
@@ -18,7 +16,7 @@ GENERAL_RX = re.compile(
     
     (?:                         # Start of a non-capturing group for the optional value
         _                       # A literal underscore separator
-        (?P<val>[\d\.]+)        # Capture group 'val': Matches digits or periods
+        (?P<val>[\d\.eE\-\+]+)  # Capture group 'val': Matches digits, periods, or scientific notation. 
     )?                          # The '?' makes the entire '_value' portion optional
     
     _                           # A literal underscore separator before the statistic
@@ -68,6 +66,9 @@ def _pack_dataset(
 
     results.columns = pd.MultiIndex.from_frame(extracted)
     results = results.stack(level=levels)  # ty: ignore[invalid-assignment]
+    # match is None is impossible because a ValueError would have already been
+    # thrown at this point.
+    assert match is not None
     im_name = match.group("im")
 
     dset = results.to_xarray()
@@ -107,6 +108,8 @@ def run_gmm_xarray(
         Frequencies to compute for EAS
     epistemic_branch : constants.EpistemicBranch
         Epistemic branch mapping
+    **kwargs : Any
+        Options passed to `wrapper.run_gmm`
 
     Returns
     -------
@@ -154,8 +157,8 @@ def run_gmm_xarray(
     >>> sorted(psa.coords.keys())
     ['model', 'period', 'station']
 
-    >>> # Get the mean for model 'd' and 'a_32' at 1.0s.
-    >>> psa['mean'].sel(station='a_32', model='d').sel(period=1.0, method='nearest').item()
+    >>> # Get the mean for model 'd' and 'a_10' at 1.0s.
+    >>> psa['mean'].sel(station='a_10', model='d').sel(period=1.0, method='nearest').item()
     ...
 
     See Also
@@ -164,7 +167,7 @@ def run_gmm_xarray(
     """
     rupture_df = inputs.to_dataframe()
 
-    df_result = run_gmm(
+    df_result = wrapper.run_gmm(
         model=model,
         tect_type=tect_type,
         rupture_df=rupture_df,
@@ -202,6 +205,8 @@ def run_gmm_logic_tree_xarray(
         Intensity measure (e.g., 'PGA', 'pSA', 'EAS')
     periods : Sequence[float | int], optional
         Periods to compute for pSA
+    **kwargs : Any
+        Keyword arguments passed to `run_gmm_logic_tree`
 
     Returns
     -------
@@ -259,8 +264,8 @@ def run_gmm_logic_tree_xarray(
     >>> sorted(psa.coords.keys())
     ['model', 'period', 'station']
 
-    >>> # Get the mean for model 'd' and 'a_32' at 1.0s.
-    >>> psa['mean'].sel(station='a_32', model='d').sel(period=1.0, method='nearest').item()
+    >>> # Get the mean for model 'd' and 'a_10' at 1.0s.
+    >>> psa['mean'].sel(station='a_10', model='d').sel(period=1.0, method='nearest').item()
     ...
 
     See Also
@@ -269,7 +274,7 @@ def run_gmm_logic_tree_xarray(
     """
     rupture_df = inputs.to_dataframe()
 
-    df_result = run_gmm_logic_tree(
+    df_result = wrapper.run_gmm_logic_tree(
         gmm_lt,
         tect_type=tect_type,
         rupture_df=rupture_df,

--- a/oq_wrapper/xarray.py
+++ b/oq_wrapper/xarray.py
@@ -41,7 +41,7 @@ def _pack_dataset(
     Returns
     -------
     Dataset
-        A multi-dimensional dataset extracted the dataframe, analysing the
+        A multi-dimensional dataset extracted from the dataframe, analysing the
         columns to extract the intensity measure, period and frequency.
     """
     test_column = results.columns[0]

--- a/oq_wrapper/xarray.py
+++ b/oq_wrapper/xarray.py
@@ -118,6 +118,12 @@ def run_gmm_xarray(
         are stored as data variables. The intensity measure type is stored
         in the global attributes.
 
+    Notes
+    -----
+    This function will materialise the full dataset as a copy in a dataframe. To
+    handle very large datasets, use `xr.map_blocks` to lazily iterate over
+    dataset chunks.
+
     Examples
     --------
     >>> import oq_wrapper as oqw
@@ -214,6 +220,12 @@ def run_gmm_logic_tree_xarray(
         A Dataset containing the GMM results. Statistics (mean, std_Total)
         are stored as data variables. The intensity measure type is stored
         in the global attributes.
+
+    Notes
+    -----
+    This function will materialise the full dataset as a copy in a dataframe. To
+    handle very large datasets, use `xr.map_blocks` to lazily iterate over
+    dataset chunks.
 
     Examples
     --------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
   "pandas[pyarrow]",
   "pyyaml",
   "scipy>=1.7.2",
+  # Suggested minimum version that handles the indexing logic in the xarray
+  # module properly.
+  "xarray>=2022.3.0",
   "source-modelling",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1554,6 +1554,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "scipy" },
     { name = "source-modelling" },
+    { name = "xarray" },
 ]
 
 [package.optional-dependencies]
@@ -1586,6 +1587,7 @@ requires-dist = [
     { name = "source-modelling" },
     { name = "tqdm", marker = "extra == 'test'", specifier = ">=4.0.0" },
     { name = "ty", marker = "extra == 'dev'" },
+    { name = "xarray", specifier = ">=2022.3.0" },
 ]
 provides-extras = ["test", "types", "dev"]
 


### PR DESCRIPTION
Adds support for multidimensional rupture inputs using xarray and its native interfacing with pandas. Input dimensions are preserved through pandas indexes.

Testing is achieved by testing the examples using doctest. I also found another set of examples in the wrapper module `wrapper._convert_from_oq_im` which I also turned into doctests for some free coverage.

## Why do we want this?
Classic example, you are benchmarking the performance of several vs30 models at a bunch of stations using a GMM as a surrogate. The models are a, b, c, d, e and you would like to get estimates for all stations for comparison at specific periods. Currently you would have to do something like 

``` python
# The "Old Way": Manual broadcasting and dataframe munging
results = []
models = ['a', 'b', 'c', 'd', 'e']
stations = [f'a_{i}' for i in range(1, 11)]
periods = [1.0, 5.0]

for model in models:
    for period in periods:
        # Manually construct a flattened dataframe for each slice
        # Must ensure rrup, vs30, and mag are all the same length
        temp_df = pd.DataFrame({
            "vs30": vs30_data[model],  # Extracting 1D array from 2D source
            "rrup": rrup_data,         # Static 1D array
            "mag": 8.3                 # Scalar needs to be broadcast by pandas
        }, index=stations)
        
        # Run the GMM on this specific slice
        res = run_gmm(..., rupture_df=temp_df, im='pSA', periods=[period])
        
        # Add metadata so we can identify this slice later
        res['model'] = model
        res['period'] = period
        res['station'] = res.index
        results.append(res)

# Concatenate everything and try to rebuild the multi-dimensional structure
df_final = pd.concat(results).set_index(['model', 'station', 'period'])

# Accessing a specific value now requires complex multi-index slicing
val = df_final.xs(('d', 'a_3', 1.0), level=['model', 'station', 'period'])['pSA_1.0_mean']

# Imagine if we wanted to get a range of periods here instead!
```

But with the new xarray example you can do this instead 
``` python
    >>> import oq_wrapper as oqw
    >>> import oq_wrapper.xarray as oqwx
    >>> import xarray as xr
    >>> import numpy as np

    >>> # Create a dataset with heterogeneous dimensions:
    >>> # rrup (station), vs30 (model, station), and mag (scalar)
    >>> rng = np.random.default_rng(seed=0)
    >>> inputs = xr.Dataset(
    ...     data_vars=dict(
    ...         rrup=('station', np.linspace(1, 100, num=10)),
    ...         vs30=(('model', 'station'), rng.uniform(500, 1500, size=(5, 10))),
    ...         mag=8.3
    ...     ),
    ...     coords=dict(
    ...         station=[f'a_{i}' for i in range(1, 11)],
    ...         model=['a', 'b', 'c', 'd', 'e']
    ...     )
    ... )

    >>> # Run the GMM across the entire dimension grid
    >>> psa = oqwx.run_gmm_xarray(
    ...     oqw.constants.GMM.A_22,
    ...     oqw.constants.TectType.ACTIVE_SHALLOW,
    ...     inputs,
    ...     'pSA',
    ...     periods=[1.0, 5.0]
    ... )

    >>> # Statistics become data variables
    >>> sorted(psa)
    ['mean', 'std_Inter', 'std_Intra', 'std_Total']

    >>> # Input dimensions are broadcast with periods (or frequencies).
    >>> sorted(psa.coords.keys())
    ['model', 'period', 'station']

    >>> # Get the mean for model 'd' and 'a_32' at 1.0.
    >>> psa['mean'].sel(station='a_32', model='d').sel(period=1.0, method='nearest').item()
    >>> # Get a bunch of periods at once
    >>> psa['mean'].sel(station='a_32', model='d').sel(period=[1.0, 1.3, 2.0], method='nearest').item()
    >>> # Compare a baseline 'a' model against all other models at every station simultaneously
    >>> psa['mean'].sel(model='a') / psa['mean'].drop_sel(model='a')
```

Notice:

1. Variables are automatically broadcast, it understands that magnitude needs to have shape (model, station).
2. Input dimensions are preserved. This prevents re-indexing bugs by eliminating manual index tracking.
3. Periods are floats instead of being embedded inside columns where complex pandas string mechanics are required.